### PR TITLE
Corrige l'impression d'enveloppe d'un personnage

### DIFF
--- a/src/LarpManager/Entities/BasePersonnage.php
+++ b/src/LarpManager/Entities/BasePersonnage.php
@@ -1678,4 +1678,22 @@ class BasePersonnage
     {
         return array('id', 'nom', 'surnom', 'intrigue', 'groupe_id', 'classe_id', 'age_id', 'genre_id', 'renomme', 'photo', 'xp', 'territoire_id', 'materiel', 'vivant', 'age_reel', 'trombineUrl', 'user_id', 'richesse', 'heroisme');
     }
+    
+    /**
+     * @return la prochaine partipcipation
+     */
+    public function prochaineParticipation()
+    {
+        $now = new \DateTime();
+        $prochain = null;
+        
+        foreach ($this->participants as $p) {
+            if($now < $p->getGn()->getDateFin()) {
+                if($prochain == null || $prochain->getGn()->getDateDebut() > $p->getGn()->getDateDebut() ) {
+                    $prochain = $p;
+                }
+            }
+        }
+        return $prochain;
+    }
 }

--- a/src/LarpManager/Views/admin/personnage/enveloppe.twig
+++ b/src/LarpManager/Views/admin/personnage/enveloppe.twig
@@ -7,14 +7,13 @@
 </div>
 
 {% if personnage.user %}
-	{% for participant in personnage.user.participants %}
 		<strong>Personnage Secondaire : </strong>
-		{% if participant.personnageSecondaire %}
+		{% if personnage.prochaineParticipation != null and personnage.prochaineParticipation.personnageSecondaire != null %}
 			{{ participant.personnageSecondaire.classe.label }}
 		{% else %}
 			PAS DE PERSONNAGE SECONDAIRE
 		{% endif %}
-	{% endfor %}
+	
 {% endif %}
 	
 <strong>Renommée :</strong> {{ personnage.renomme|default(0) }}<br />


### PR DESCRIPTION
Corrige l'impression d'enveloppe d'un personnage qui récupérait les
persos secondaires de toutes les participations ratachés au personnage