### PR TITLE
Corrige la compétence "Littérature Apprentie"

### DIFF
--- a/src/LarpManager/Controllers/ParticipantController.php
+++ b/src/LarpManager/Controllers/ParticipantController.php
@@ -2816,14 +2816,14 @@ class ParticipantController
 					case 1: // 2 langues très répandue supplémentaires de son choix
 						$trigger = new \LarpManager\Entities\PersonnageTrigger();
 						$trigger->setPersonnage($personnage);
-						$trigger->setTag('LANGUE COMMUNE');
+						$trigger->setTag('LANGUE COURANTE');
 						$trigger->setDone(false);
 						$app['orm.em']->persist($trigger);
 						$app['orm.em']->flush();
 						
 						$trigger = new \LarpManager\Entities\PersonnageTrigger();
 						$trigger->setPersonnage($personnage);
-						$trigger->setTag('LANGUE COMMUNE');
+						$trigger->setTag('LANGUE COURANTE');
 						$trigger->setDone(false);
 						$app['orm.em']->persist($trigger);
 						$app['orm.em']->flush();

--- a/src/LarpManager/Controllers/ParticipantController.php
+++ b/src/LarpManager/Controllers/ParticipantController.php
@@ -2887,7 +2887,7 @@ class ParticipantController
 						$trigger->setDone(false);
 						$app['orm.em']->persist($trigger);
 						$app['orm.em']->flush();
-						
+						 
 						$trigger = new \LarpManager\Entities\PersonnageTrigger();
 						$trigger->setPersonnage($personnage);
 						$trigger->setTag('LANGUE COURANTE');


### PR DESCRIPTION
Corrige la compétence "Littérature Apprentie" qui donne accès maintenant à 2 langue courante à la place de 2 langues commune.