### PR TITLE
Fix redirect personnage

### DIFF
--- a/src/LarpManager/Controllers/ForumController.php
+++ b/src/LarpManager/Controllers/ForumController.php
@@ -116,7 +116,7 @@ class ForumController
 			
 			$app['session']->getFlashBag()->add('success', 'Le forum a été ajouté.');
 			
-			return $app->redirect($app['url_generator']->generate('forum'),301);
+			return $app->redirect($app['url_generator']->generate('forum'),303);
 		}
 		
 		return $app['twig']->render('forum/forum_add.twig', array(
@@ -186,7 +186,7 @@ class ForumController
 			
 			$app['session']->getFlashBag()->add('success', 'Le message a été ajouté.');
 			
-			return $app->redirect($app['url_generator']->generate('forum.topic',array('index'=> $topic->getId())),301);
+			return $app->redirect($app['url_generator']->generate('forum.topic',array('index'=> $topic->getId())),303);
 		}
 			
 		return $app['twig']->render('forum/post_add.twig', array(
@@ -292,7 +292,7 @@ class ForumController
 				
 			$app['session']->getFlashBag()->add('success', 'Le message a été ajouté.');
 				
-			return $app->redirect($app['url_generator']->generate('forum.post',array('index'=> $postToResponse->getId())),301);
+			return $app->redirect($app['url_generator']->generate('forum.post',array('index'=> $postToResponse->getId())),303);
 		}
 	
 		return $app['twig']->render('forum/post_response.twig', array(
@@ -330,7 +330,7 @@ class ForumController
 	
 			$app['session']->getFlashBag()->add('success', 'Le message a été modifié.');
 	
-			return $app->redirect($app['url_generator']->generate('forum.post',array('index'=> $post->getId())),301);
+			return $app->redirect($app['url_generator']->generate('forum.post',array('index'=> $post->getId())),303);
 		}
 	
 		return $app['twig']->render('forum/post_update.twig', array(
@@ -357,7 +357,7 @@ class ForumController
 		$app['orm.em']->flush();
 		
 		$app['session']->getFlashBag()->add('success', 'Les notifications sont maintenant activées.');
-		return $app->redirect($app['url_generator']->generate('forum.post',array('index'=> $post->getId())),301);
+		return $app->redirect($app['url_generator']->generate('forum.post',array('index'=> $post->getId())),303);
 	}
 	
 	/**
@@ -378,7 +378,7 @@ class ForumController
 		$app['orm.em']->flush();
 	
 		$app['session']->getFlashBag()->add('success', 'Les notifications sont maintenant desactivées.');
-		return $app->redirect($app['url_generator']->generate('forum.post',array('index'=> $post->getId())),301);
+		return $app->redirect($app['url_generator']->generate('forum.post',array('index'=> $post->getId())),303);
 	}
 	
 	/**
@@ -438,7 +438,7 @@ class ForumController
 			
 			$app['session']->getFlashBag()->add('success', 'Le message a été supprimé.');
 			
-			return $app->redirect($url,301);
+			return $app->redirect($url,303);
 		}
 		
 		return $app['twig']->render('forum/post_delete.twig', array(
@@ -481,7 +481,7 @@ class ForumController
 		
 			$app['session']->getFlashBag()->add('success', 'Le forum a été ajouté.');
 		
-			return $app->redirect($app['url_generator']->generate('forum.topic',array('index'=> $topic->getId())),301);
+			return $app->redirect($app['url_generator']->generate('forum.topic',array('index'=> $topic->getId())),303);
 		}
 		
 		return $app['twig']->render('forum/topic_add.twig', array(
@@ -527,7 +527,7 @@ class ForumController
 	
 			$app['session']->getFlashBag()->add('success', 'Le forum a été modifié.');
 	
-			return $app->redirect($app['url_generator']->generate('forum.topic',array('index'=> $topic->getId())),301);
+			return $app->redirect($app['url_generator']->generate('forum.topic',array('index'=> $topic->getId())),303);
 		}
 	
 		return $app['twig']->render('forum/topic_update.twig', array(

--- a/src/LarpManager/Controllers/GnController.php
+++ b/src/LarpManager/Controllers/GnController.php
@@ -58,7 +58,7 @@ class GnController
             // L'utilisateur n'a pas validé les CG.
             return $app->redirect($app['url_generator']->generate('user.gn.validationci', array(
                 'gn' => $gn->getId()
-            )), 307);            
+            )), 303);            
         }
                 
         $repo = $app['orm.em']->getRepository('LarpManager\Entities\Question');
@@ -85,7 +85,7 @@ class GnController
             $app['session']->getFlashBag()->add('error', 'Vous n\'avez pas encore de personnage.');
             return $app->redirect($app['url_generator']->generate('gn.detail', array(
                 'gn' => $gn->getId()
-            )), 301);
+            )), 303);
         }
         $lois = $app['orm.em']->getRepository('LarpManager\Entities\Loi')->findAll();
         return $app['twig']->render('public/personnage/detail.twig', array(
@@ -251,7 +251,7 @@ class GnController
             $app['orm.em']->persist($gn);
             $app['orm.em']->flush();
             $app['session']->getFlashBag()->add('success', 'Le gn a été ajouté.');
-            return $app->redirect($app['url_generator']->generate('gn.list'), 301);
+            return $app->redirect($app['url_generator']->generate('gn.list'), 303);
         }
         return $app['twig']->render('gn/add.twig', array(
             'form' => $form->createView()

--- a/src/LarpManager/Controllers/ParticipantController.php
+++ b/src/LarpManager/Controllers/ParticipantController.php
@@ -127,7 +127,7 @@ class ParticipantController
 		$app['orm.em']->flush();
 		
 		$app['session']->getFlashBag()->add('Success','Votre réponse a été prise en compte !');
-		return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+		return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		
 	}
 	
@@ -145,7 +145,7 @@ class ParticipantController
 		$app['orm.em']->flush();
 		
 		$app['session']->getFlashBag()->add('Success','Votre réponse a été supprimée, veuillez répondre de nouveau à la question !');
-		return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+		return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 	}
 	
 	/**
@@ -174,7 +174,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success', 'Vos modifications ont été enregistré.');
-			return $app->redirect($app['url_generator']->generate('user.admin.list', array()),307);
+			return $app->redirect($app['url_generator']->generate('user.admin.list', array()),303);
 		}
 		
 		return $app['twig']->render('admin/participant/new.twig', array(
@@ -206,7 +206,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success', 'Vos modifications ont été enregistré.');
-			return $app->redirect($app['url_generator']->generate('gn.participants', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.participants', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/participant/groupe.twig', array(
@@ -269,7 +269,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success', 'Vos modifications ont été enregistré.');
-			return $app->redirect($app['url_generator']->generate('gn.participants', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.participants', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/participant/remove.twig', array(
@@ -303,7 +303,7 @@ class ParticipantController
 			$app['notify']->newBillet($participant->getUser(), $participant->getBillet());
 			
 			$app['session']->getFlashBag()->add('success', 'Vos modifications ont été enregistré.');
-			return $app->redirect($app['url_generator']->generate('gn.participants', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.participants', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/participant/billet.twig', array(
@@ -362,7 +362,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success', 'Vos modifications ont été enregistrés.');
-			return $app->redirect($app['url_generator']->generate('gn.participants', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.participants', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/participant/restauration.twig', array(
@@ -384,7 +384,7 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error','Vous n\'avez pas encore de personnage.');
-			return $app->redirect($app['url_generator']->generate('participant.index', array('participant' => $participant->getId())),307);
+			return $app->redirect($app['url_generator']->generate('participant.index', array('participant' => $participant->getId())),303);
 		}
 
 		$lois = $app['orm.em']->getRepository('LarpManager\Entities\Loi')->findAll();
@@ -410,13 +410,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error','Vous n\'avez pas encore de personnage.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		if ( ! $personnage->hasCompetence('Politique') )
 		{
 			$app['session']->getFlashBag()->add('error','Votre personnage ne dispose pas de la compétence Politique');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 				
 		// recherche de tous les groupes participant au prochain GN
@@ -455,7 +455,7 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error','Vous n\'avez pas encore de personnage.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		$form = $app['form.factory']->createBuilder(new PersonnageEditForm(), $personnage)
@@ -471,7 +471,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Vos modifications ont été prises en compte.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		return $app['twig']->render('public/personnage/edit.twig', array(
@@ -505,7 +505,7 @@ class ParticipantController
 	
 			if (!$extension || ! in_array($extension, array('png', 'jpg', 'jpeg','bmp'))) {
 				$app['session']->getFlashBag()->add('error','Désolé, votre image ne semble pas valide (vérifiez le format de votre image)');
-				return $app->redirect($app['url_generator']->generate('participant.personnage.trombine', array('participant' => $participant->getId(), 'personnage' => $personnage->getId())),307);
+				return $app->redirect($app['url_generator']->generate('participant.personnage.trombine', array('participant' => $participant->getId(), 'personnage' => $personnage->getId())),303);
 			}
 	
 			$trombineFilename = hash('md5',$app['user']->getUsername().$filename . time()).'.'.$extension;
@@ -519,7 +519,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Votre photo a été enregistrée');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/personnage/trombine.twig', array(
@@ -580,25 +580,25 @@ class ParticipantController
 		if ( ! $groupeGn )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous devez rejoindre un groupe avant de pouvoir créer votre personnage.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		if ( ! $participant->getBillet() )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous devez avoir un billet avant de pouvoir créer votre personnage.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 		
 		if ( $groupeGn->getGroupe()->getLock() == true)
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, ce groupe est fermé. La création de personnage est temporairement désactivé.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 		
 		if ( $participant->getPersonnage() )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous disposez déjà d\'un personnage.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 		
 		$groupe = $groupeGn->getGroupe();
@@ -642,7 +642,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Votre personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 		
 		return $app['twig']->render('public/participant/personnage_old.twig', array(
@@ -703,7 +703,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('gn.participants.withoutperso', array('gn' => $gn->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.participants.withoutperso', array('gn' => $gn->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/participant/personnage_old.twig', array(
@@ -726,25 +726,25 @@ class ParticipantController
 		if ( ! $groupeGn )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous devez rejoindre un groupe avant de pouvoir créer votre personnage.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' =>  $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' =>  $participant->getGn()->getId())),303);
 		}
 		
 		if ( ! $participant->getBillet() )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous devez avoir un billet avant de pouvoir créer votre personnage.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 
 		if ( $groupeGn->getGroupe()->getLock() == true)
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, ce groupe est fermé. La création de personnage est temporairement désactivé.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 	
 		if ( $participant->getPersonnage() )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous disposez déjà d\'un personnage.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 		
 		$groupe = $groupeGn->getGroupe();
@@ -752,7 +752,7 @@ class ParticipantController
 		/*if (  ! $groupe->hasEnoughClasse($groupeGn->getGn()) )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, ce groupe ne contient plus de classes disponibles');
-			return $app->redirect($app['url_generator']->generate('participant.index', array('participant' => $participant->getId())),307);
+			return $app->redirect($app['url_generator']->generate('participant.index', array('participant' => $participant->getId())),303);
 		}*/
 	
 		$personnage = new \LarpManager\Entities\Personnage();
@@ -874,7 +874,7 @@ class ParticipantController
 	
 	
 			$app['session']->getFlashBag()->add('success','Votre personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 	
 		$ages = $app['orm.em']->getRepository('LarpManager\Entities\Age')->findAllOnCreation();
@@ -1020,7 +1020,7 @@ class ParticipantController
 	
 	
 			$app['session']->getFlashBag()->add('success','Votre personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('gn.participants.withoutperso', array('gn' => $groupeGn->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.participants.withoutperso', array('gn' => $groupeGn->getGn()->getId())),303);
 		}
 	
 		$ages = $app['orm.em']->getRepository('LarpManager\Entities\Age')->findAllOnCreation();
@@ -1094,7 +1094,7 @@ class ParticipantController
 		if ( ! $participant->getBillet() )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous devez obtenir un billet avant de pouvoir rejoindre un groupe');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 				
 		$form = $app['form.factory']->createBuilder(new GroupeInscriptionForm(), array())
@@ -1113,21 +1113,21 @@ class ParticipantController
 				if ( ! $groupe )
 				{
 					$app['session']->getFlashBag()->add('error','Désolé, le code que vous utilisez ne correspond à aucun groupe');
-					return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+					return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 				}
 				
 				$groupeGn = $groupe->getGroupeGn($participant->getGn());
 				if ( ! $groupeGn )
 				{
 					$app['session']->getFlashBag()->add('error','Le code correspond à un groupe qui ne participe pas à cette session de jeu.');
-					return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+					return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 				}
 				
 				// il faut que le groupe ai un responsable pour le rejoindre
 				if ( ! $groupeGn->getResponsable() )
 				{
 					$app['session']->getFlashBag()->add('error','Le groupe n\'a pas encore de responsable, vous ne pouvez pas le rejoindre pour le moment.');
-					return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+					return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 				}
 					
 				$participant->setGroupeGn($groupeGn);
@@ -1138,7 +1138,7 @@ class ParticipantController
 				$app['notify']->joinGroupe($participant, $groupeGn);
 						
 				$app['session']->getFlashBag()->add('success','Vous avez rejoint le groupe.');
-				return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);				
+				return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);				
 		}
 		
 		return $app['twig']->render('public/groupe/join.twig', array(
@@ -1173,7 +1173,7 @@ class ParticipantController
 	
 			$app['session']->getFlashBag()->add('success','Le personnage secondaire a été enregistré.');
 						
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGroupeGn()->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGroupeGn()->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/participant/personnageSecondaire.twig', array(
@@ -1197,7 +1197,7 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, Vous devez faire votre personnage pour pouvoir consulter votre background.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		$backsGroupe = new ArrayCollection();
@@ -1249,19 +1249,19 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous devez créer un personnage avant de choisir son origine.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		if ( $personnage->getGroupe()->getLock() == true)
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, il n\'est plus possible de modifier ce personnage. Le groupe est verouillé. Contacter votre scénariste si vous pensez que cela est une erreur');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( $personnage->getTerritoire() )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, il n\'est pas possible de modifier votre origine. Veuillez contacter votre orga pour exposer votre problème.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		$form = $app['form.factory']->createBuilder(new PersonnageOriginForm(), $personnage)
@@ -1277,7 +1277,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Votre personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/participant/origine.twig', array(
@@ -1317,13 +1317,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage avant de choisir une religion !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 				
 		if ( $participant->getGroupeGn()->getGroupe()->getLock() == true)
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, il n\'est plus possible de modifier ce personnage. Le groupe est verouillé. Contacter votre scénariste si vous pensez que cela est une erreur');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 	
@@ -1331,7 +1331,7 @@ class ParticipantController
 		if ( $personnage->isFanatique() )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous êtes un Fanatique, il vous est impossible de choisir une nouvelle religion. Veuillez contacter votre orga en cas de problème.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		$personnageReligion = new \LarpManager\Entities\PersonnagesReligions();
@@ -1343,7 +1343,7 @@ class ParticipantController
 		if ( $availableReligions->count() == 0 )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, il n\'y a plus de religion disponibles ( Sérieusement ? vous êtes éclectique, c\'est bien, mais ... faudrait savoir ce que vous voulez non ? L\'heure n\'est-il pas venu de faire un choix parmi tous ces dieux ?)');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		// construit le tableau de choix
@@ -1385,7 +1385,7 @@ class ParticipantController
 				if ( $personnage->isFervent() )
 				{
 					$app['session']->getFlashBag()->add('error','Désolé, vous êtes déjà Fervent d\'une autre religion, il vous est impossible de choisir une nouvelle religion en tant que Fervent. Veuillez contacter votre orga en cas de problème.');
-					return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+					return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 				}
 			}
 	
@@ -1393,7 +1393,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Votre personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/personnage/religion_add.twig', array(
@@ -1419,13 +1419,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		if ( ! $personnage->isKnownPriere($priere) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas cette prière !');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		return $app['twig']->render('public/priere/detail.twig', array(
@@ -1450,13 +1450,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		if ( ! $personnage->isKnownPriere($priere) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas cette prière !');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 			
 		$file = __DIR__.'/../../../private/doc/'.$priere->getDocumentUrl();
@@ -1479,13 +1479,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->isKnownPotion($potion) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas cette potion !');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/potion/detail.twig', array(
@@ -1510,13 +1510,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->isKnownPotion($potion) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas cette potion !');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 			
 		$file = __DIR__.'/../../../private/doc/'.$potion->getDocumentUrl();
@@ -1536,7 +1536,7 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		$niveau = $request->get('niveau');
@@ -1547,7 +1547,7 @@ class ParticipantController
 				&& ! $personnage->hasTrigger('ALCHIMIE MAITRE') )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous ne pouvez pas choisir de potions supplémentaires.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		$repo = $app['orm.em']->getRepository('\LarpManager\Entities\Potion');
@@ -1601,7 +1601,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Vos modifications ont été enregistrées.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('personnage/potion.twig', array(
@@ -1627,13 +1627,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		if ( ! $personnage->hasTrigger('PRETRISE INITIE') )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous ne pouvez pas choisir de descriptif de religion supplémentaire.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		$availableDescriptionReligion = $app['personnage.manager']->getAvailableDescriptionReligion($personnage);
@@ -1666,7 +1666,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Vos modifications ont été enregistrées.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 			
 		return $app['twig']->render('public/personnage/descriptionReligion.twig', array(
@@ -1690,13 +1690,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->hasTrigger('LANGUE COMMUNE') )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous ne pouvez pas choisir de langue commune supplémentaire.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		$availableLangues = $app['personnage.manager']->getAvailableLangues($personnage, 2);
@@ -1733,7 +1733,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Vos modifications ont été enregistrées.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/personnage/langueCommune.twig', array(
@@ -1757,13 +1757,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->hasTrigger('LANGUE COURANTE') )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous ne pouvez pas choisir de langue courante supplémentaire.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		$availableLangues = $app['personnage.manager']->getAvailableLangues($personnage, 1);
@@ -1800,7 +1800,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Vos modifications ont été enregistrées.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/personnage/langueCourante.twig', array(
@@ -1824,13 +1824,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->hasTrigger('LANGUE ANCIENNE') )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous ne pouvez pas choisir de langue ancienne supplémentaire.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		$availableLangues = $app['personnage.manager']->getAvailableLangues($personnage, 0);
@@ -1867,7 +1867,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Vos modifications ont été enregistrées.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/personnage/langueAncienne.twig', array(
@@ -1890,13 +1890,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->hasTrigger('DOMAINE MAGIE') )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous ne pouvez pas choisir de domaine de magie supplémentaire.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		$availableDomaines = $app['personnage.manager']->getAvailableDomaines($personnage);
@@ -1932,7 +1932,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Vos modifications ont été enregistrées.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 			
 		}
 		
@@ -1957,7 +1957,7 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		$niveau = $request->get('niveau');
@@ -1968,7 +1968,7 @@ class ParticipantController
 				&& ! $personnage->hasTrigger('SORT MAITRE') )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, vous ne pouvez pas choisir de sortilèges supplémentaires.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		$sorts = $app['personnage.manager']->getAvailableSorts($personnage, $niveau);
@@ -2021,7 +2021,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Vos modifications ont été enregistrées.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('personnage/sort.twig', array(
@@ -2048,13 +2048,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->isKnownSort($sort) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas ce sort !');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/sort/detail.twig', array(
@@ -2079,13 +2079,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->isKnownSort($sort) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas ce sort !');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 			
 		$file = __DIR__.'/../../../private/doc/'.$sort->getDocumentUrl();
@@ -2106,7 +2106,7 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		$domaines = $app['orm.em']->getRepository('\LarpManager\Entities\Domaine')->findAll();
@@ -2149,13 +2149,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->isKnownCompetence($competence) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas cette competence !');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/competence/detail.twig', array(
@@ -2197,13 +2197,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		if ( ! $personnage->isKnownCompetence($competence) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas cette competence !');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 			
 		$file = __DIR__.'/../../../private/doc/'.$competence->getDocumentUrl();
@@ -2244,7 +2244,7 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage avant de postuler à un groupe secondaire!');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		/**
@@ -2253,7 +2253,7 @@ class ParticipantController
 		if ( $groupeSecondaire->isPostulant($personnage) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Votre avez déjà postulé dans ce groupe. Inutile d\'en refaire la demande.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		/**
@@ -2262,7 +2262,7 @@ class ParticipantController
 		if ( $groupeSecondaire->isMembre($personnage) )
 		{
 			$app['session']->getFlashBag()->add('error', 'Votre êtes déjà membre de ce groupe. Inutile d\'en refaire la demande.');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		/**
@@ -2303,7 +2303,7 @@ class ParticipantController
 					
 				$app['session']->getFlashBag()->add('success', 'Votre candidature a été enregistrée, et transmise au chef de groupe.');
 		
-				return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+				return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 			}
 		}
 	
@@ -2328,13 +2328,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		if ( ! $membre )
 		{
 			$app['session']->getFlashBag()->add('error', 'Votre n\'êtes pas membre de ce groupe.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/groupeSecondaire/detail.twig', array(
@@ -2377,7 +2377,7 @@ class ParticipantController
 			$app['notify']->acceptGroupeSecondaire($personnage->getUser(), $groupeSecondaire);
 				
 			$app['session']->getFlashBag()->add('success', 'Vous avez accepté la candidature. Un message a été envoyé au joueur concerné.');
-			return $app->redirect($app['url_generator']->generate('participant.groupeSecondaire.detail', array('participant' => $participant->getId(), 'groupeSecondaire' => $groupeSecondaire->getId())),307);
+			return $app->redirect($app['url_generator']->generate('participant.groupeSecondaire.detail', array('participant' => $participant->getId(), 'groupeSecondaire' => $groupeSecondaire->getId())),303);
 		}
 	
 		return $app['twig']->render('public/groupeSecondaire/gestion_accept.twig', array(
@@ -2411,7 +2411,7 @@ class ParticipantController
 			$app['notify']->rejectGroupeSecondaire($personnage->getUser(), $groupeSecondaire);
 	
 			$app['session']->getFlashBag()->add('success', 'Vous avez refusé la candidature. Un message a été envoyé au joueur concerné.');
-			return $app->redirect($app['url_generator']->generate('participant.groupeSecondaire.detail', array('participant' => $participant->getId(), 'groupeSecondaire' => $groupeSecondaire->getId())),307);
+			return $app->redirect($app['url_generator']->generate('participant.groupeSecondaire.detail', array('participant' => $participant->getId(), 'groupeSecondaire' => $groupeSecondaire->getId())),303);
 		}
 	
 	
@@ -2447,7 +2447,7 @@ class ParticipantController
 			$app['notify']->waitGroupeSecondaire($personnage->getUser(), $groupeSecondaire);
 	
 			$app['session']->getFlashBag()->add('success', 'La candidature reste en attente. Un message a été envoyé au joueur concerné.');
-			return $app->redirect($app['url_generator']->generate('participant.groupeSecondaire.detail', array('participant' => $participant->getId(), 'groupeSecondaire' => $groupeSecondaire->getId())),307);
+			return $app->redirect($app['url_generator']->generate('participant.groupeSecondaire.detail', array('participant' => $participant->getId(), 'groupeSecondaire' => $groupeSecondaire->getId())),303);
 		}
 	
 	
@@ -2490,7 +2490,7 @@ class ParticipantController
 			$app['notify']->newMessage($postulant->getPersonnage()->getUser(), $message);
 	
 			$app['session']->getFlashBag()->add('success', 'Votre message a été envoyé au joueur concerné.');
-			return $app->redirect($app['url_generator']->generate('participant.groupeSecondaire.detail', array('participant' => $participant->getId(), 'groupeSecondaire' => $groupeSecondaire->getId())),307);
+			return $app->redirect($app['url_generator']->generate('participant.groupeSecondaire.detail', array('participant' => $participant->getId(), 'groupeSecondaire' => $groupeSecondaire->getId())),303);
 		}
 	
 	
@@ -2515,13 +2515,13 @@ class ParticipantController
 		if ( ! $personnage )
 		{
 			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créer un personnage !');
-			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),303);
 		}
 		
 		if ( $participant->getGroupeGn()->getGroupe()->getLock() == true)
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, il n\'est plus possible de modifier ce personnage. Le groupe est verouillé. Contacter votre scénariste si vous pensez que cela est une erreur');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		$availableCompetences = $app['personnage.manager']->getAvailableCompetences($personnage);
@@ -2529,7 +2529,7 @@ class ParticipantController
 		if ( $availableCompetences->count() == 0 )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, il n\'y a plus de compétence disponible (Bravo !).');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		// construit le tableau de choix
@@ -2562,7 +2562,7 @@ class ParticipantController
 			if ( $xp - $cout < 0 )
 			{
 				$app['session']->getFlashBag()->add('error','Vos n\'avez pas suffisement de point d\'expérience pour acquérir cette compétence.');
-				return $app->redirect($app['url_generator']->generate('homepage'),307);
+				return $app->redirect($app['url_generator']->generate('homepage'),303);
 			}
 			$personnage->setXp($xp - $cout);
 			$personnage->addCompetence($competence);
@@ -2651,7 +2651,7 @@ class ParticipantController
 				else
 				{
 					$app['session']->getFlashBag()->add('error','Pour obtenir la compétence Prêtrise, vous devez être FERVENT ou FANATIQUE');
-					return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+					return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 				}
 			}
 			
@@ -2912,7 +2912,7 @@ class ParticipantController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Votre personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),307);
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),303);
 		}
 	
 		return $app['twig']->render('public/personnage/competence.twig', array(
@@ -2950,7 +2950,7 @@ class ParticipantController
 	
 			$app['session']->getFlashBag()->add('success', 'Vos informations ont été enregistrés.');
 	
-			return $app->redirect($app['url_generator']->generate('homepage'),307);
+			return $app->redirect($app['url_generator']->generate('homepage'),303);
 		}
 	
 		return $app['twig']->render('joueur/add.twig', array(
@@ -3001,12 +3001,12 @@ class ParticipantController
 				if ( $joueurs->count() == 0 )
 				{
 					$app['session']->getFlashBag()->add('error', 'Le joueur n\'a pas été trouvé.');
-					return $app->redirect($app['url_generator']->generate('homepage'), 301);
+					return $app->redirect($app['url_generator']->generate('homepage'),303);
 				}
 				else if ( $joueurs->count() == 1 )
 				{
 					$app['session']->getFlashBag()->add('success', 'Le joueur a été trouvé.');
-					return $app->redirect($app['url_generator']->generate('joueur.detail.orga', array('index'=> $joueurs->first()->getId())),307);
+					return $app->redirect($app['url_generator']->generate('joueur.detail.orga', array('index'=> $joueurs->first()->getId())),303);
 				}
 				else
 				{

--- a/src/LarpManager/Controllers/PersonnageController.php
+++ b/src/LarpManager/Controllers/PersonnageController.php
@@ -79,7 +79,7 @@ class PersonnageController
 	public function selectAction(Request $request, Application $app, Personnage $personnage)
 	{
 		$app['personnage.manager']->setCurrentPersonnage($personnage->getId());		
-		return $app->redirect($app['url_generator']->generate('homepage'),307);
+		return $app->redirect($app['url_generator']->generate('homepage'),303);
 	}
 	
 	/**
@@ -92,7 +92,7 @@ class PersonnageController
 	public function unselectAction(Request $request, Application $app)
 	{
 		$app['personnage.manager']->resetCurrentPersonnage();
-		return $app->redirect($app['url_generator']->generate('homepage'),307);
+		return $app->redirect($app['url_generator']->generate('homepage'),303);
 	}
 		
 	/**
@@ -140,7 +140,7 @@ class PersonnageController
 		
 			if (!$extension || ! in_array($extension, array('png', 'jpg', 'jpeg','bmp'))) {
 				$app['session']->getFlashBag()->add('error','Désolé, votre image ne semble pas valide (vérifiez le format de votre image)');
-				return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),307);
+				return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),303);
 			}
 		
 			$trombineFilename = hash('md5',$app['user']->getUsername().$filename . time()).'.'.$extension;
@@ -154,7 +154,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success','La photo a été enregistrée');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),303);
 		}
 		return $app['twig']->render('admin/personnage/trombine.twig', array(
 				'personnage' => $personnage,
@@ -189,7 +189,7 @@ class PersonnageController
 			
 			$app['personnage.manager']->setCurrentPersonnage($personnage);
 			$app['session']->getFlashBag()->add('success', 'Votre personnage a été créé');
-			return $app->redirect($app['url_generator']->generate('homepage'),307);
+			return $app->redirect($app['url_generator']->generate('homepage'),303);
 		}
 		
 		return $app['twig']->render('public/personnage/new.twig', array(
@@ -232,7 +232,7 @@ class PersonnageController
 			if ( ! $token )
 			{
 				$app['session']->getFlashBag()->add('error', 'Le jeton VIEILLESSE n\'existe pas !');
-				return $app->redirect($app['url_generator']->generate('homepage'),307);
+				return $app->redirect($app['url_generator']->generate('homepage'),303);
 			}
 			
 			foreach ( $personnages as $personnage)
@@ -263,7 +263,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success', 'tous les personnages ont reçut un jeton vieillesse.');
-			return $app->redirect($app['url_generator']->generate('homepage'),307);
+			return $app->redirect($app['url_generator']->generate('homepage'),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/vieillir.twig', array(
@@ -294,7 +294,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/age.twig', array(
@@ -326,7 +326,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/updateTechnologie.twig', array(
@@ -384,7 +384,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/materiel.twig', array(
@@ -416,7 +416,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le statut du personnage a été modifié');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/statut.twig', array(
@@ -480,7 +480,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été transféré');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/transfert.twig', array(
@@ -614,7 +614,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Les points d\'expériences ont été ajoutés');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);			
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);			
 		}
 		
 		return $app['twig']->render('admin/personnage/xp.twig', array(
@@ -706,11 +706,11 @@ class PersonnageController
 			$app['session']->getFlashBag()->add('success','Votre personnage a été sauvegardé.');
 			if ( $participant->getGroupe())
 			{
-				return $app->redirect($app['url_generator']->generate('groupe.detail', array('index' => $participant->getGroupe()->getId())),307);
+				return $app->redirect($app['url_generator']->generate('groupe.detail', array('index' => $participant->getGroupe()->getId())),303);
 			}
 			else
 			{
-				return $app->redirect($app['url_generator']->generate('homepage'),307);
+				return $app->redirect($app['url_generator']->generate('homepage'),303);
 			}
 		}
 		
@@ -804,7 +804,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été supprimé.');
-			return $app->redirect($app['url_generator']->generate('homepage'),307);
+			return $app->redirect($app['url_generator']->generate('homepage'),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/delete.twig', array(
@@ -837,7 +837,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/update.twig', array(
@@ -878,7 +878,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success','Le background a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/addBackground.twig', array(
@@ -918,7 +918,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success','Le background a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/updateBackground.twig', array(
@@ -958,7 +958,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/updateRenomme.twig', array(
@@ -998,7 +998,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/updateHeroisme.twig', array(
@@ -1036,7 +1036,7 @@ class PersonnageController
 		$app['orm.em']->flush();
 	
 		$app['session']->getFlashBag()->add('success','Le jeton '.$token->getTag().' a été ajouté.');
-		return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+		return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 	}
 	
 	/**
@@ -1057,7 +1057,7 @@ class PersonnageController
 		$app['orm.em']->flush();
 		
 		$app['session']->getFlashBag()->add('success','Le jeton a été retiré.');
-		return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+		return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 	}
 	
 	/**
@@ -1083,7 +1083,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success','Le déclencheur a été ajouté.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/addTrigger.twig', array(
@@ -1113,7 +1113,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success','Le déclencheur a été supprimé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/deleteTrigger.twig', array(
@@ -1171,7 +1171,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/updateDomaine.twig', array(
@@ -1263,7 +1263,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 	
 		return $app['twig']->render('admin/personnage/updateLangue.twig', array(
@@ -1317,7 +1317,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 	
 		return $app['twig']->render('admin/personnage/updatePriere.twig', array(
@@ -1351,7 +1351,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/updateSort.twig', array(
@@ -1384,7 +1384,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 	
 		return $app['twig']->render('admin/personnage/updatePotion.twig', array(
@@ -1461,7 +1461,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 	
 		return $app['twig']->render('admin/personnage/ingredients.twig', array(
@@ -1559,7 +1559,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 	
 		return $app['twig']->render('admin/personnage/ressources.twig', array(
@@ -1588,7 +1588,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 	
 		return $app['twig']->render('admin/personnage/richesse.twig', array(
@@ -1618,7 +1618,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success', 'Le document a été ajouté au personnage.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),303);
 		}
 	
 		return $app['twig']->render('admin/personnage/documents.twig', array(
@@ -1648,7 +1648,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 	
 			$app['session']->getFlashBag()->add('success', 'L\'objet a été ajouté au personnage.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),303);
 		}
 	
 		return $app['twig']->render('admin/personnage/items.twig', array(
@@ -1671,7 +1671,7 @@ class PersonnageController
 		if ( $personnage->isFanatique() )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, le personnage êtes un Fanatique, il vous est impossible de choisir une nouvelle religion. (supprimer la religion fanatique qu\'il possède avant)' );
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		$personnageReligion = new \LarpManager\Entities\PersonnagesReligions();
@@ -1683,7 +1683,7 @@ class PersonnageController
 		if ( $availableReligions->count() == 0 )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, il n\'y a plus de religion disponibles');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		// construit le tableau de choix
@@ -1725,7 +1725,7 @@ class PersonnageController
 				if ( $personnage->isFervent() )
 				{
 					$app['session']->getFlashBag()->add('error','Désolé, vous êtes déjà Fervent d\'une autre religion, il vous est impossible de choisir une nouvelle religion en tant que Fervent. Veuillez contacter votre orga en cas de problème.');
-					return $app->redirect($app['url_generator']->generate('homepage'),307);
+					return $app->redirect($app['url_generator']->generate('homepage'),303);
 				}
 			}
 						
@@ -1733,7 +1733,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/addReligion.twig', array(
@@ -1767,7 +1767,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/removeReligion.twig', array(
@@ -1802,7 +1802,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/removeLangue.twig', array(
@@ -1860,7 +1860,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 		
 			$app['session']->getFlashBag()->add('success','Le personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		return $app['twig']->render('admin/personnage/updateOrigine.twig', array(
@@ -1882,7 +1882,7 @@ class PersonnageController
 		
 		if ( ! $lastCompetence ) {
 			$app['session']->getFlashBag()->add('error','Désolé, le personnage n\'a pas encore acquis de compétences');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);
 		}
 		
 		$form = $app['form.factory']->createBuilder()
@@ -1942,7 +1942,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 			
 			$app['session']->getFlashBag()->add('success','La compétence a été retirée');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),307);			
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail',array('personnage'=>$personnage->getId())),303);			
 		}
 		
 		return $app['twig']->render('admin/personnage/removeCompetence.twig', array(
@@ -1962,7 +1962,7 @@ class PersonnageController
 		if ( $availableCompetences->count() == 0 )
 		{
 			$app['session']->getFlashBag()->add('error','Désolé, il n\'y a plus de compétence disponible.');
-			return $app->redirect($app['url_generator']->generate('homepage'),307);
+			return $app->redirect($app['url_generator']->generate('homepage'),303);
 		}
 		
 		// construit le tableau de choix
@@ -1995,7 +1995,7 @@ class PersonnageController
 			if ( $xp - $cout < 0 )
 			{
 				$app['session']->getFlashBag()->add('error','Vos n\'avez pas suffisement de point d\'expérience pour acquérir cette compétence.');
-				return $app->redirect($app['url_generator']->generate('homepage'),307);
+				return $app->redirect($app['url_generator']->generate('homepage'),303);
 			}
 			$personnage->setXp($xp - $cout);
 			$personnage->addCompetence($competence);
@@ -2014,7 +2014,7 @@ class PersonnageController
 			$app['orm.em']->flush();
 				
 			$app['session']->getFlashBag()->add('success','Votre personnage a été sauvegardé.');
-			return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),307);
+			return $app->redirect($app['url_generator']->generate('personnage.admin.detail', array('personnage' => $personnage->getId())),303);
 		}
 			
 		return $app['twig']->render('admin/personnage/competence.twig', array(


### PR DESCRIPTION
Gregory  a constaté qu'on n'avait suite au passage en 307 des erreurs de ce type dans les logs du serveurs :
 Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException: No route found for "POST /gn/5/personnage": Method Not Allowed (Allow: GET) (uncaught exception)

Après échange, il apparait que le 307 maintient la methode d'origine POST de la requête pendant la redirection.
alors qu'un 303 permettrait une redirection systématique en GET
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303