### PR TITLE
Ajoute les sorts secrets + fix

### DIFF
--- a/src/LarpManager/Entities/BaseLangue.php
+++ b/src/LarpManager/Entities/BaseLangue.php
@@ -306,7 +306,7 @@ class BaseLangue
      * Set the value of secret.
      *
      * @param boolean $secret
-     * @return \LarpManager\Entities\Potion
+     * @return \LarpManager\Entities\Langue
      */
     public function setSecret($secret)
     {

--- a/src/LarpManager/Entities/BaseSort.php
+++ b/src/LarpManager/Entities/BaseSort.php
@@ -56,6 +56,11 @@ class BaseSort
     protected $domaine;
 
     /**
+     * @Column(type="boolean", nullable=false, options={"default":0})
+     */
+    protected $secret;
+
+    /**
      * @ManyToMany(targetEntity="Personnage", mappedBy="sorts")
      */
     protected $personnages;
@@ -238,6 +243,30 @@ class BaseSort
     {
         return $this->personnages;
     }
+
+    /**
+     * Set the value of secret.
+     *
+     * @param boolean $secret
+     * @return \LarpManager\Entities\Sort
+     */
+    public function setSecret($secret)
+    {
+        $this->secret = $secret;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of secret.
+     *
+     * @return boolean
+     */
+    public function getSecret()
+    {
+        return $this->secret;
+    }
+
 
     public function __sleep()
     {

--- a/src/LarpManager/Form/Potion/PotionForm.php
+++ b/src/LarpManager/Form/Potion/PotionForm.php
@@ -61,7 +61,6 @@ class PotionForm extends AbstractType
 								
 						),
 						'label' => 'Secret'
-						
 				))
 				->add('document','file', array(
 						'label' => 'Téléversez un document',

--- a/src/LarpManager/Form/SortForm.php
+++ b/src/LarpManager/Form/SortForm.php
@@ -64,8 +64,9 @@ class SortForm extends AbstractType
 					'required' => false,
 					'label' => 'Description',
 					'attr' => array(
-					'class' => 'tinymce',
-					'rows' => 9),
+						'class' => 'tinymce',
+						'rows' => 9
+					),
 				))
 				->add('secret', 'choice', array(
 					'required' => true,

--- a/src/LarpManager/Form/SortForm.php
+++ b/src/LarpManager/Form/SortForm.php
@@ -64,8 +64,16 @@ class SortForm extends AbstractType
 					'required' => false,
 					'label' => 'Description',
 					'attr' => array(
-							'class' => 'tinymce',
-							'rows' => 9),
+					'class' => 'tinymce',
+					'rows' => 9),
+				))
+				->add('secret', 'choice', array(
+					'required' => true,
+					'choices' => array(
+							false => 'Sort visible',
+							true => 'Sort secret',
+					),
+					'label' => 'Secret'
 				));
 	}
 	

--- a/src/LarpManager/Repository/SortRepository.php
+++ b/src/LarpManager/Repository/SortRepository.php
@@ -36,7 +36,7 @@ class SortRepository extends EntityRepository
 	public function findByNiveau($niveau)
 	{
 		$sorts = $this->getEntityManager()
-				->createQuery('SELECT s FROM LarpManager\Entities\Sort s Where s.niveau = '.$niveau.' ORDER BY s.label ASC')
+				->createQuery('SELECT s FROM LarpManager\Entities\Sort s Where s.niveau = '.$niveau.' AND (s.secret = 0 OR s.secret IS NULL) ORDER BY s.label ASC')
 				->getResult();
 		
 		return $sorts;

--- a/src/LarpManager/Views/admin/sort/detail.twig
+++ b/src/LarpManager/Views/admin/sort/detail.twig
@@ -11,6 +11,11 @@
 	</ol>
 
 	<div class="list-group">
+		{% if sort.secret %}
+		<div class="list-group-item">
+			<div class="list-group-item-heading"><h6><span style="color:red;">Sort secret</span></h6></div>
+		</div>
+		{% endif %}
 		<div class="list-group-item">
 			<div class="list-group-item-heading"><h6>Label</h6></div>
 			<div class="list-group-item-text">{{ sort.label }}</div>
@@ -34,9 +39,6 @@
 	    	</p>
     	</div>
 	</div>
-	
-	
-	
 	<div class="panel panel-default">
 		<div class="panel-heading"><h4>Description</h4></div>
 		<div class="panel-body">

--- a/src/LarpManager/Views/admin/sort/list.twig
+++ b/src/LarpManager/Views/admin/sort/list.twig
@@ -19,6 +19,9 @@
 			<li class="list-group-item">
 				<div class="row">
 					<div class="col-md-8">
+						{% if sort.secret %}
+						<span style="color:red;">Sort secret</span><br />
+						{% endif %}
 						{{ sort.label }} -- {{ sort.niveau }}
 						{{ sort.description|markdown }}
 						{% if sort.documentUrl %}


### PR DESCRIPTION
- Ajoute la gestion des sorts secrets (ils ne sont pas visibles dans les vues des joueurs, à part en les ayant appris, mais les admins/scénaristes peuvent les donner à un joueur).
- Corrige un bug dans les langues secrètes
- Ajout du champ "secret" dans la table "sort" de la BDD