### PR TITLE
Improve secondary group

### DIFF
--- a/src/LarpManager/Controllers/GroupeSecondaireController.php
+++ b/src/LarpManager/Controllers/GroupeSecondaireController.php
@@ -52,24 +52,51 @@ class GroupeSecondaireController
 	 */
 	public function adminListAction(Request $request, Application $app)
 	{
-		$order_by = $request->get('order_by') ?: 'label';
+		$order_by = $request->get('order_by') ?: 'id';
 		$order_dir = $request->get('order_dir') == 'DESC' ? 'DESC' : 'ASC';
 		$limit = (int)($request->get('limit') ?: 50);
 		$page = (int)($request->get('page') ?: 1);
 		$offset = ($page - 1) * $limit;
+		$criteria = array();
 		
-		$form = $app['form.factory']->createBuilder(new SecondaryGroupFindForm())
+		$form = $app['form.factory']->createBuilder(
+				new SecondaryGroupFindForm(),
+				null,
+				array(
+					'method' => 'get',
+					'csrf_protection' => false
+				)
+			)
 			->add('find','submit', array('label' => 'Rechercher'))
 			->getForm();
 		
-		$criteria = array();
-		
+		$form->handleRequest($request);
+
+		if ( $form->isValid() )
+		{
+			$data = $form->getData();
+			$type = $data['type'];
+			$value = $data['value'];
+			switch ($type){
+				case 'nom':
+				    // $criteria[] = new LikeExpression("p.nom", "%$value%");
+				    $criteria["nom"] = "g.label like '%".preg_replace('/[\'"<>=*;]/', '', $value)."%'";
+					break;
+				case 'id':
+				    // $criteria[] = new EqualExpression("p.id", $value);
+				    $criteria["id"] = "g.id = ".preg_replace('/[^\d]/', '', $value);
+					break;								
+			}
+		}
+
+		/* @var SecondaryGroupRepository $repo */
 		$repo = $app['orm.em']->getRepository('\LarpManager\Entities\SecondaryGroup');
-		$groupeSecondaires = $repo->findBy(
+		$groupeSecondaires = $repo->findList(
 				$criteria,
-				array( $order_by => $order_dir),
+				array( 'by' =>  $order_by, 'dir' => $order_dir),
 				$limit,
-				$offset);
+				$offset
+		);
 		
 		$numResults = $repo->findCount($criteria);
 		

--- a/src/LarpManager/Entities/Personnage.php
+++ b/src/LarpManager/Entities/Personnage.php
@@ -633,25 +633,54 @@ class Personnage extends BasePersonnage
 	public function getIdentity()
 	{
 		$groupeLabel = null;
+		$nomGn = '???';
 		if ( $this->getUser() )
 		{
 			foreach ( $this->getUser()->getParticipants() as $participant )
 			{
 				if( $participant->getPersonnage() == $this )
 				{
+					$nomGn = $this->getGns()->last();
 					$groupeGn = $participant->getGroupeGn();
-					$groupeLabel = $groupeGn->getGroupe()->getNom();
-					$nomGn = $participant->getGn();
+					if ($groupeGn != null)
+						$groupeLabel = $groupeGn->getGroupe()->getNom();
 				}
 			}
 		}
-
 		$identity = $this->getNom().' - '.$this->getSurnom().' (';
-		if ( $groupeLabel ){
-			if ( !$nomGn ) $nomGN = '???';
+		if ( $groupeLabel )
 			$identity .= $nomGn.' - '.$groupeLabel;
-		} 
-		else $identity .= '*** GROUPE NON INDENTIFIABLE ***';
+		else 
+			$identity .= $nomGn.' - *** GROUPE NON INDENTIFIABLE ***';
+		$identity .= ')';
+		return $identity;
+	}
+
+	/**
+	 * Fourni l'identité publique d'un personnage
+	 */
+	public function getPublicIdentity()
+	{
+		$groupeLabel = null;
+		$nomGn = '???';
+		if ( $this->getUser() )
+		{
+			foreach ( $this->getUser()->getParticipants() as $participant )
+			{
+				if( $participant->getPersonnage() == $this )
+				{
+					$nomGn = $this->getGns()->last();
+					$groupeGn = $participant->getGroupeGn();
+					if ($groupeGn != null)
+						$groupeLabel = $groupeGn->getGroupe()->getNom();
+				}
+			}
+		}
+		$identity = $this->getPublicName().' (';
+		if ( $groupeLabel )
+			$identity .= $nomGn.' - '.$groupeLabel;
+		else 
+			$identity .= $nomGn.' - *** GROUPE NON INDENTIFIABLE ***';
 		$identity .= ')';
 		return $identity;
 	}
@@ -676,6 +705,7 @@ class Personnage extends BasePersonnage
 	public function getIdentityByLabel($gnLabel)
 	{
 		$groupeLabel = null;
+		$nomGn = $gnLabel;
 		if ( $this->getUser() )
 		{
 			foreach ( $this->getUser()->getParticipants() as $participant )
@@ -685,13 +715,16 @@ class Personnage extends BasePersonnage
 					&& $participant->getPersonnage() == $this )
 				{
 					$groupeGn = $participant->getGroupeGn();
-					$groupeLabel = $groupeGn->getGroupe()->getNom();
+					if ($groupeGn != null)
+						$groupeLabel = $groupeGn->getGroupe()->getNom();
 				}
 			}
 		}
-
-		$identity = $this->getNom().' - '.$this->getSurnom().' (';
-		if ( $groupeLabel ) $identity .= $groupeLabel;
+		$identity = $this->getPublicName().' (';
+		if ( $groupeLabel )
+			$identity .= $nomGn.' - '.$groupeLabel;
+		else 
+			$identity .= $nomGn.' - *** GROUPE NON INDENTIFIABLE ***';
 		$identity .= ')';
 		return $identity;
 	}

--- a/src/LarpManager/Form/GroupeSecondaire/SecondaryGroupFindForm.php
+++ b/src/LarpManager/Form/GroupeSecondaire/SecondaryGroupFindForm.php
@@ -40,14 +40,16 @@ class SecondaryGroupFindForm extends AbstractType
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
-		$builder->add('search','text', array(
+		$builder->add('value','text', array(
 						'required' => true,
+						'label' => 'Valeur',
 				))
 				->add('type', 'choice', array(
 						'required' => true,
+						'label' => 'Type',
 						'choices' => array(
-							'numero' => 'Numéro',
-							'group_name' => 'Nom du groupe',
+							'id' => 'Numéro',
+							'nom' => 'Nom du groupe secondaire',
 						)
 				));
 	}

--- a/src/LarpManager/GroupeSecondaireControllerProvider.php
+++ b/src/LarpManager/GroupeSecondaireControllerProvider.php
@@ -61,7 +61,7 @@ class GroupeSecondaireControllerProvider implements ControllerProviderInterface
 		 */		
 		$controllers->match('/admin/list','LarpManager\Controllers\GroupeSecondaireController::adminListAction')
 			->bind("groupeSecondaire.admin.list")
-			->method('GET')
+			->method('GET|POST')
 			->before($mustBeOrga);
 			
 		/**

--- a/src/LarpManager/Repository/SecondaryGroupRepository.php
+++ b/src/LarpManager/Repository/SecondaryGroupRepository.php
@@ -41,9 +41,35 @@ class SecondaryGroupRepository extends EntityRepository
 	
 		return $groupes;
 	}
-	
+
 	/**
-	 * Trouve les groupes secondaires correspondant aux critères de recherche
+	 * Trouve les groupes secondaires correspondants aux critères de recherche
+	 * 
+	 * @param array $criteria
+	 * @param array $order
+	 * @param unknown $limit
+	 * @param unknown $offset
+	 */
+	public function findList(array $criteria = array(), array $order = array(), $limit, $offset)
+	{
+		$qb = $this->getEntityManager()->createQueryBuilder();
+
+		$qb->select('distinct g');
+		$qb->from('LarpManager\Entities\SecondaryGroup','g');
+
+		foreach ( $criteria as $critere )
+		{
+			$qb->andWhere($critere);
+		}
+
+		$qb->setFirstResult($offset);
+		$qb->setMaxResults($limit);
+		$qb->orderBy('g.'.$order['by'], $order['dir']);
+		return $qb->getQuery()->getResult();
+	}	
+
+	/**
+	 * Compte les groupes secondaires correspondants aux critères de recherche
 	 *
 	 * @param array $criteria
 	 * @param array $options
@@ -55,9 +81,9 @@ class SecondaryGroupRepository extends EntityRepository
 		$qb->select($qb->expr()->count('g'));
 		$qb->from('LarpManager\Entities\SecondaryGroup','g');
 	
-		foreach ( $criteria as $criter )
+		foreach ( $criteria as $critere )
 		{
-			$qb->addWhere($criter);
+			$qb->andWhere($critere);
 		}
 	
 		return $qb->getQuery()->getSingleScalarResult();

--- a/src/LarpManager/Views/admin/groupeSecondaire/list.twig
+++ b/src/LarpManager/Views/admin/groupeSecondaire/list.twig
@@ -32,8 +32,7 @@
 		   	</li>
 		   	<li class="list-group-item">
 		   		<div class="list-group-item"><h6>Rechercher</h6></div>
-		   		
-		   		<form class="form" action="{{ path('groupeSecondaire.admin.list') }}" method="POST" {{ form_enctype(form) }}>
+		   		<form class="form" action="{{ path('groupeSecondaire.admin.list') }}" method="GET" {{ form_enctype(form) }}>
 					{% form_theme form 'Form/bootstrap_3_horizontal_layout.html.twig' %}
 					{{ form(form) }}
 		   		</form>

--- a/src/LarpManager/Views/admin/groupeSecondaire/print.twig
+++ b/src/LarpManager/Views/admin/groupeSecondaire/print.twig
@@ -10,7 +10,7 @@
 	<h6>Liste des membres</h6>
 	<ul>
 	{% for membre in groupeSecondaire.membres %}
-		<li>{{ membre.personnage.identity }}</li>
+		<li>{{ membre.personnage.publicidentity }}</li>
 	{% endfor %}
 	</ul>
 	

--- a/src/LarpManager/Views/admin/groupeSecondaire/print.twig
+++ b/src/LarpManager/Views/admin/groupeSecondaire/print.twig
@@ -2,18 +2,17 @@
 
 {% block content %}
 
-	<h2>Groupe {{ groupeSecondaire.label }}</h2>
+	<h2>Groupe {% if groupeSecondaire.secret%}secret{% endif %} : {{ groupeSecondaire.label }}</h2>
 	{% if groupeSecondaire.responsable %}
 	<strong>Responsable : {{ groupeSecondaire.responsable }}</strong>
 	{% endif %}
 	
-	<h6>Liste des membres</h6>
+	<h4>Liste des membres</h4>
 	<ul>
 	{% for membre in groupeSecondaire.membres %}
 		<li>{{ membre.personnage.publicidentity }}</li>
 	{% endfor %}
 	</ul>
-	
 
 	<p>{{ groupeSecondaire.materiel }}</p>
 	

--- a/src/LarpManager/Views/admin/groupeSecondaire/printAll.twig
+++ b/src/LarpManager/Views/admin/groupeSecondaire/printAll.twig
@@ -11,7 +11,7 @@
 	<h6>Liste des membres</h6>
 	<ul>
 	{% for membre in groupeSecondaire.membres %}
-		<li>{{ membre.personnage.identity }}</li>
+		<li>{{ membre.personnage.publicidentity }}</li>
 	{% endfor %}
 	</ul>
 

--- a/src/LarpManager/Views/admin/groupeSecondaire/printAll.twig
+++ b/src/LarpManager/Views/admin/groupeSecondaire/printAll.twig
@@ -3,12 +3,11 @@
 {% block content %}
 
 {% for groupeSecondaire in groupeSecondaires %}
-	<h2>Groupe {{ groupeSecondaire.label }}</h2>
+	<h2>Groupe {% if groupeSecondaire.secret%}secret{% endif %} : {{ groupeSecondaire.label }}</h2>
 	{% if groupeSecondaire.responsable %}
 	<strong>Responsable : {{ groupeSecondaire.responsable }}</strong>
 	{% endif %}
-	
-	<h6>Liste des membres</h6>
+	<h4>Liste des membres</h4>
 	<ul>
 	{% for membre in groupeSecondaire.membres %}
 		<li>{{ membre.personnage.publicidentity }}</li>

--- a/src/LarpManager/Views/admin/groupeSecondaire/reponse.twig
+++ b/src/LarpManager/Views/admin/groupeSecondaire/reponse.twig
@@ -15,7 +15,7 @@
 		
 		<form action="{{ path('groupeSecondaire.admin.reponse', {'index': groupeSecondaire.id, 'postulantId': postulant.id}) }}" method="POST" {{ form_enctype(form) }} novalidate>
 			<fieldset>
-				<legend>Accepter ou refuser la candidature de {{ postulant.personnage.identity }}</legend>
+				<legend>Accepter ou refuser la candidature de {{ postulant.personnage.publicidentity }}</legend>
 					{{ postulant.explanation|markdown }}
 					{% form_theme form 'Form/bootstrap_3_layout.html.twig' %}
 					{{ form(form) }}

--- a/src/LarpManager/Views/public/groupeSecondaire/detail.twig
+++ b/src/LarpManager/Views/public/groupeSecondaire/detail.twig
@@ -69,6 +69,7 @@
 					<a class="btn btn-danger" 
 						href="{{ path('participant.groupeSecondaire.reject', {'participant': participant.id, 'groupeSecondaire': groupeSecondaire.id, 'postulant': postulant.id }) }}">
 						Rejeter</a>
+					<br />
 				</div>
 			{% endfor %}
 			</ul>
@@ -120,14 +121,23 @@
 		
 		<div class="row">
 		{% for membre in groupeSecondaire.membres %}
-			<div class="col-xs-6 col-md-3">
-				{% if membre.personnage.trombineUrl %}
-					<img width="160" src="{{ path('personnage.trombine', {'personnage' : membre.personnage.id }) }}" />
+			{% if membre.personnage.participeTo(participant.gn) %}
+				<div class="col-xs-6 col-md-3">
+					{% if membre.personnage.trombineUrl %}
+						<img width="160" src="{{ path('personnage.trombine', {'personnage' : membre.personnage.id }) }}" />
+					{% endif %}
 					<div class="caption">
 						{{ membre.personnage.publicName }}
+						{% if groupeSecondaire.responsable %}
+							{% if groupeSecondaire.secondaryGroupType.label == 'Religion' %}
+								{% for personnageReligion in membre.personnage.personnagesReligions %}
+									<li>{{ personnageReligion.religion.label }} - {{ personnageReligion.religionLevel.label }}</li>
+								{% endfor %}
+							{% endif %}
+						{% endif %}
 					</div>
-				{% endif %}
-			</div>
+				</div>
+			{% endif %}
 		{% endfor %}
 		</div>
 		

--- a/src/LarpManager/Views/public/groupeSecondaire/detail.twig
+++ b/src/LarpManager/Views/public/groupeSecondaire/detail.twig
@@ -124,7 +124,9 @@
 			{% if membre.personnage.participeTo(participant.gn) %}
 				<div class="col-xs-6 col-md-3">
 					{% if membre.personnage.trombineUrl %}
-						<img width="160" src="{{ path('personnage.trombine', {'personnage' : membre.personnage.id }) }}" />
+						<img class="media-object" width="160" src="{{ path('personnage.trombine', {'personnage' : membre.personnage.id }) }}" />
+					{% else %}
+						<img class="media-object" width="160" src="{{ app.request.basepath }}/img/no_trombine.png" />
 					{% endif %}
 					<div class="caption">
 						{{ membre.personnage.publicName }}


### PR DESCRIPTION
- les chefs de groupe religieux peuvent voir les religions de ses membres, comme à la postulation.
- les gens ne partagent "que" leur identité publique dans les groupes secondaires. (surnom, nom si pas de surnom et groupe)
- les admins peuvent rechercher les groupes secondaires