### PR TITLE
Ajout des documents des langues

### DIFF
--- a/src/LarpManager/Controllers/ParticipantController.php
+++ b/src/LarpManager/Controllers/ParticipantController.php
@@ -75,6 +75,7 @@ use LarpManager\Entities\Groupe;
 use LarpManager\Entities\Rule;
 use LarpManager\Entities\Question;
 use LarpManager\Entities\Reponse;
+use LarpManager\Entities\Langue;
 
 
 /**
@@ -1891,6 +1892,35 @@ class ParticipantController
 				'personnage' => $personnage,
 				'participant' => $participant,
 		));
+	}
+
+	/**
+	 * Obtenir le document lié à une langue
+	 *
+	 * @param Request $request
+	 * @param Application $app
+	 * @param Participant $participant
+	 * @param Langue $langue
+	 */
+	public function langueDocumentAction(Request $request, Application $app, Participant $participant, Langue $langue)
+	{
+		$personnage = $participant->getPersonnage();
+	
+		if ( ! $personnage )
+		{
+			$app['session']->getFlashBag()->add('error', 'Vous devez avoir créé un personnage !');
+			return $app->redirect($app['url_generator']->generate('gn.detail', array('gn' => $participant->getGn()->getId())),301);
+		}
+	
+		if ( ! $personnage->isKnownLanguage($langue) )
+		{
+			$app['session']->getFlashBag()->add('error', 'Vous ne connaissez pas cette langue !');
+			return $app->redirect($app['url_generator']->generate('gn.personnage', array('gn' => $participant->getGn()->getId())),301);
+		}
+			
+		$file = __DIR__.'/../../../private/doc/'.$langue->getDocumentUrl();
+		return $app->sendFile($file)
+			    ->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE, $langue->getPrintLabel().'.pdf');
 	}
 	
 	/**

--- a/src/LarpManager/Entities/BaseLangue.php
+++ b/src/LarpManager/Entities/BaseLangue.php
@@ -72,6 +72,11 @@ class BaseLangue
      */
     protected $secret;
 
+    /**
+     * @Column(type="string", length=45, nullable=true)
+     */
+    protected $documentUrl;
+
     public function __construct()
     {
         $this->personnageLangues = new ArrayCollection();
@@ -323,6 +328,29 @@ class BaseLangue
     public function getSecret()
     {
         return $this->secret;
+    }
+
+    /**
+     * Set the value of documentUrl.
+     *
+     * @param boolean $documentUrl
+     * @return \LarpManager\Entities\Langue
+     */
+    public function setDocumentUrl($documentUrl)
+    {
+        $this->documentUrl = $documentUrl;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of sedocumentUrlcret.
+     *
+     * @return boolean
+     */
+    public function getDocumentUrl()
+    {
+        return $this->documentUrl;
     }
 
     public function __sleep()

--- a/src/LarpManager/Entities/Langue.php
+++ b/src/LarpManager/Entities/Langue.php
@@ -98,4 +98,9 @@ class Langue extends BaseLangue
 			default : return 'Inconnue';
 		}
 	}
+
+	public function getPrintLabel()
+	{
+		return preg_replace('/[^a-z0-9]+/', '_', strtolower($this->getLabel()));
+	}	
 }

--- a/src/LarpManager/Form/LangueForm.php
+++ b/src/LarpManager/Form/LangueForm.php
@@ -72,7 +72,13 @@ class LangueForm extends AbstractType
 							true => 'Langue secrète',
 					),
 					'label' => 'Secret'
-				));
+				))
+				->add('document','file', array(
+					'label' => 'Téléversez un document',
+					'required' => false,
+					'mapped' => false
+				))
+			;
 	}
 	
 	/**

--- a/src/LarpManager/ParticipantControllerProvider.php
+++ b/src/LarpManager/ParticipantControllerProvider.php
@@ -416,9 +416,6 @@ class ParticipantControllerProvider implements ControllerProviderInterface
 			->convert('groupeSecondaire', 'converter.secondaryGroup:convert')
 			->convert('postulant', 'converter.postulant:convert')
 			->before($mustBeResponsable);
-
-			
-			
 			
 		/**
 		 * Liste des religions
@@ -587,6 +584,18 @@ class ParticipantControllerProvider implements ControllerProviderInterface
 			->assert('competence', '\d+')
 			->convert('competence', 'converter.competence:convert')
 			->bind("participant.competence.document")
+			->method('GET')
+			->before($mustOwnParticipant);
+
+		/**
+		 * Obtenir le document lié à une langue
+		 */
+		$controllers->match('/{participant}/langue/{langue}/document/{filename}','LarpManager\Controllers\ParticipantController::langueDocumentAction')
+			->assert('participant', '\d+')
+			->convert('participant', 'converter.participant:convert')
+			->assert('langue', '\d+')
+			->convert('langue', 'converter.langue:convert')
+			->bind("participant.langue.document")
 			->method('GET')
 			->before($mustOwnParticipant);
 			

--- a/src/LarpManager/Services/Converter/LangueConverter.php
+++ b/src/LarpManager/Services/Converter/LangueConverter.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * LarpManager - A Live Action Role Playing Manager
+ * Copyright (C) 2016 Kevin Polez
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace LarpManager\Services\Converter;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * LarpManager\Services\Converter\LangueConverter
+ */
+class LangueConverter
+{
+	/**
+	 * 
+	 * @var EntityManager
+	 */
+    private $em;
+
+    /**
+     * Constructeur
+     * 
+     * @param EntityManager $em
+     */
+    public function __construct(EntityManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * Fourni la religion d'un personnage à partir de son identifiant
+     * 
+     * @param unknown $id
+     * @throws NotFoundHttpException
+     * @return LarpManager\Entities\Langue
+     */
+    public function convert($id)
+    {
+    	$langue = $this->em->find('\LarpManager\Entities\Langue',(int) $id);
+    	
+        if (null === $langue) {
+            throw new NotFoundHttpException(sprintf('La langue %d n\'existe pas', $id));
+        }
+
+        return $langue;
+    }
+}

--- a/src/LarpManager/Services/LarpManagerServiceProvider.php
+++ b/src/LarpManager/Services/LarpManagerServiceProvider.php
@@ -54,6 +54,7 @@ use LarpManager\Services\Converter\GroupeGnConverter;
 use LarpManager\Services\Converter\IngredientConverter;
 use LarpManager\Services\Converter\IntrigueConverter;
 use LarpManager\Services\Converter\ItemConverter;
+use LarpManager\Services\Converter\LangueConverter;
 use LarpManager\Services\Converter\LieuConverter;
 use LarpManager\Services\Converter\LoiConverter;
 use LarpManager\Services\Converter\MembreConverter;
@@ -295,6 +296,11 @@ class LarpManagerServiceProvider implements ServiceProviderInterface
 			return new ReligionConverter($app['orm.em']);
 		});
 		
+		// langue converter
+		$app['converter.langue'] = $app->share(function($app) {
+			return new LangueConverter($app['orm.em']);
+		});
+
 		// personnageLangue converter
 		$app['converter.personnageLangue'] = $app->share(function($app) {
 			return new PersonnageLangueConverter($app['orm.em']);

--- a/src/LarpManager/Views/admin/personnage/detail.twig
+++ b/src/LarpManager/Views/admin/personnage/detail.twig
@@ -192,7 +192,7 @@
 								{% endfor %}
 							</div>
 							
-							<h6>Langages connus</h6>
+							<h6>Langues connues</h6>
 							{% set languesAnomalie = personnage.getLanguesAnomaliesMessage() %}
 							{% if languesAnomalie != "" %}
 							<div class="text-warning">{{languesAnomalie}}</div>

--- a/src/LarpManager/Views/admin/potion/detail.twig
+++ b/src/LarpManager/Views/admin/potion/detail.twig
@@ -27,9 +27,7 @@
 	    	</p>
     	</div>
 	</div>
-	
-	
-	
+
 	<div class="panel panel-default">
 		<div class="panel-heading"><h4>Description</h4></div>
 		<div class="panel-body">

--- a/src/LarpManager/Views/langue/add.twig
+++ b/src/LarpManager/Views/langue/add.twig
@@ -1,7 +1,6 @@
 {% extends "layout.twig" %}
 
 {% block content %}
-
 	<div class="container-fluid">
 		<div class="row">
 			<div class="col-xs-12 col-md-8">

--- a/src/LarpManager/Views/langue/detail.twig
+++ b/src/LarpManager/Views/langue/detail.twig
@@ -70,7 +70,28 @@
 						</ul>
 					</p>
 				</div>
-				
+
+	    		<div class="list-group-item">
+		    		<h4 class="list-group-item-heading">Liste des documents rédigés dans cette langue ({{ langue.documents|length }} documents)</h4>
+    				<p class="list-group-item-text">
+						<ul>
+						{% for document in langue.documents %}
+							<li>{{ document.titre }}</li>
+						{% endfor %}
+						</ul>
+					</p>
+				</div>
+
+				<div class="list-group-item">
+					<h4 class="list-group-item-heading">Abécédaire</h4>
+					<p class="list-group-item-text">
+						{% if langue.documentUrl %}
+							<a href="{{ path('langue.admin.document',{'langue': langue.id}) }}">Téléchargez l'abécédaire</a>.
+						{% else %}
+							Aucun abécédaire n'est disponible.
+						{% endif %}
+					</p>
+				</div>
 				<div class="list-group-item">
   					<div class="btn-group" role="group" aria-label="...">
   						<a  class="btn btn-primary" role="button" href="{{ path('langue.update', {index : langue.id}) }}">Modifier</a>

--- a/src/LarpManager/Views/langue/detail.twig
+++ b/src/LarpManager/Views/langue/detail.twig
@@ -86,7 +86,7 @@
 					<h4 class="list-group-item-heading">Abécédaire</h4>
 					<p class="list-group-item-text">
 						{% if langue.documentUrl %}
-							<a href="{{ path('langue.admin.document',{'langue': langue.id}) }}">Téléchargez l'abécédaire</a>.
+							<a href="{{ path('langue.admin.document',{'langue': langue.id}) }}">Téléchargez</a>
 						{% else %}
 							Aucun abécédaire n'est disponible.
 						{% endif %}

--- a/src/LarpManager/Views/langue/fragment/list.twig
+++ b/src/LarpManager/Views/langue/fragment/list.twig
@@ -24,7 +24,7 @@
 		
 		<p class="list-group-item-text">
 			{%  if langue.territoires|length > 0 %}
-				Cette langue est la langue principale des territoires suivants : {{ langue.territoires|join(', ') }}				
+				Cette langue est la langue principale des territoires suivants : {{ langue.territoires|join(', ') }}.
 			{% else %}
 				Cette langue n'est la langue principale d'aucun territoire.	
 			{% endif %}
@@ -32,11 +32,27 @@
 		
 		<p class="list-group-item-text">
 			{%  if langue.territoireSecondaires|length > 0 %}
-				Cette langue est parlée dans les territoires suivants : {{ langue.territoireSecondaires|join(', ') }}
+				Cette langue est parlée dans les territoires suivants : {{ langue.territoireSecondaires|join(', ') }}.
 			{% else %}
 				Cette langue n'est la langue secondaire d'aucun territoire.
 			{% endif %}
 		</p>
+
+		<p class="list-group-item-text">
+			{%  if langue.documents|length > 0 %}
+				Cette langue est utilisée dans {{ langue.documents|length }} document{%  if langue.documents|length > 1 %}s{% endif %}.
+			{% else %}
+				Cette langue n'est utilisée dans aucun document.
+			{% endif %}
+		</p>
+
+		<p class="list-group-item-text">
+			{% if langue.documentUrl %}
+				<strong>Abécédaire : </strong><a href="{{ path('langue.admin.document',{'langue': langue.id}) }}">Téléchargez l'abécédaire</a>.
+			{% else %}
+				Aucun abécédaire n'est disponible.
+			{% endif %}
+    	</p>		
 	</li>
 	{%  endfor %}
 </ul>

--- a/src/LarpManager/Views/langue/fragment/list.twig
+++ b/src/LarpManager/Views/langue/fragment/list.twig
@@ -48,7 +48,7 @@
 
 		<p class="list-group-item-text">
 			{% if langue.documentUrl %}
-				<strong>Abécédaire : </strong><a href="{{ path('langue.admin.document',{'langue': langue.id}) }}">Téléchargez l'abécédaire</a>.
+				<strong>Abécédaire : </strong><a href="{{ path('langue.admin.document',{'langue': langue.id}) }}">Téléchargez</a>
 			{% else %}
 				Aucun abécédaire n'est disponible.
 			{% endif %}

--- a/src/LarpManager/Views/personnage/detail.twig
+++ b/src/LarpManager/Views/personnage/detail.twig
@@ -221,7 +221,7 @@
 				</div>
 				
 				<div class="list-group-item">
-					<h6 class="list-group-item-heading">Langages connus</h6>
+					<h6 class="list-group-item-heading">Langues connues</h6>
 					<p class="list-group-item-text">
 						<ul>
 						{% for personnageLangue in personnage.personnageLangues %}

--- a/src/LarpManager/Views/public/personnage/fragment/language.twig
+++ b/src/LarpManager/Views/public/personnage/fragment/language.twig
@@ -1,10 +1,17 @@
 {# languages connu #}
 <div class="header">
-	<h5>Langages connus</h5>
+	<h5>Langues connues</h5>
 </div>
 
 <ul class="list-group">
 	{% for personnageLangue in personnage.personnageLangues %}
-		<li class="list-group-item"><strong>{{ personnageLangue.langue }}</strong>&nbsp;<small>(obtenu grace à votre {{ personnageLangue.source }})</small>{{ personnageLangue.langue.description|markdown }}</li>
+		<li class="list-group-item"><strong>{{ personnageLangue.langue }}</strong>&nbsp;<small>(obtenu grace à votre {{ personnageLangue.source }})</small><br />
+		{{ personnageLangue.langue.description|markdown }}
+		{% if personnageLangue.langue.documentUrl %}
+		<a class="btn btn-default btn-sm" href="{{ path('participant.langue.document',{'participant': participant.id, 'langue' : personnageLangue.langue.id, 'filename': personnageLangue.langue.printlabel }) }}">
+			<i class="fa fa-file"></i> Voir l'abécédaire
+		</a>
+    	{% endif %}
+		</li>
 	{% endfor %}
 </ul>


### PR DESCRIPTION
- Les admins peuvent ajouter un document à une langue.
- Les joueurs possédant cette langue peuvent télécharger le document associé.
- Les admins peuvent voir combien de documents enregistrés sur le LarpManager utilisent cette langue.