### PR TITLE
#207 [Admin] Ajouter un statut PNJ au personnage

### DIFF
--- a/src/LarpManager/Entities/Billet.php
+++ b/src/LarpManager/Entities/Billet.php
@@ -98,4 +98,12 @@ class Billet extends BaseBillet
 	{
 		return $this->getGn()->getLabel(). ' - ' . $this->getLabel();
 	}
+	
+	/**
+	 * Indique si le billet est pour un PNJ ou non
+	 */
+	public function isPnj() : bool
+	{
+	    return stripos($this->getLabel(), 'PNJ') > 0; 
+	}
 }

--- a/src/LarpManager/Entities/Gn.php
+++ b/src/LarpManager/Entities/Gn.php
@@ -212,16 +212,9 @@ class Gn extends BaseGn
 		
 		foreach( $this->getParticipants() as $participant)
 		{
-			if ( $participant->getBillet() )
+			if ( $participant->isPnj() )
 			{
-				if ( $participant->getBillet()->getLabel() ==  'Inscription PNJ')
-				{
-					$participants[] = $participant;
-				}
-				if ( $participant->getBillet()->getLabel() ==  'Gratuit PNJ')
-				{
-					$participants[] = $participant;
-				}
+			    $participants->add($participant);
 			}
 		}
 		

--- a/src/LarpManager/Entities/Participant.php
+++ b/src/LarpManager/Entities/Participant.php
@@ -109,4 +109,17 @@ class Participant extends BaseParticipant
 	public function getBesoinValidationCi() {
 	   return $this->getGn()->getBesoinValidationCi() && $this->getValideCiLe() == null;
 	}
+	
+	/**
+	 * Retourne true si le participant a un billet PNJ, false sinon
+	 */
+	public function isPnj() : bool
+	{
+	    if ($this->getBillet())
+	    {
+	        return $this->getBillet()->isPnj();
+	    }
+	    return false;
+	}
+	
 }

--- a/src/LarpManager/Entities/Personnage.php
+++ b/src/LarpManager/Entities/Personnage.php
@@ -1141,4 +1141,31 @@ class Personnage extends BasePersonnage
 	public function getDescendants()
 	{
 	}	
+	
+	/**
+	 * Retourne le dernier participant du personnage
+	 *
+	 */
+	public function getLastParticipant() : \LarpManager\Entities\Participant
+	{
+	    if (!$this->getParticipants()->isEmpty())
+	    {
+	        return $this->getParticipants()->last();
+	    }
+	    return null;
+	}
+	
+	/**
+	 * Indique si le dernier participant était un PNJ ou non
+	 */
+	public function isPnj() : bool
+	{
+	    $lastParticipant = $this->getLastParticipant();
+	    if ($lastParticipant)
+	    {
+	        return $lastParticipant->isPnj();
+	    }
+	    return false;
+	}
+	
 }

--- a/src/LarpManager/GnControllerProvider.php
+++ b/src/LarpManager/GnControllerProvider.php
@@ -149,6 +149,15 @@ class GnControllerProvider implements ControllerProviderInterface
 			->before($mustBeAdmin);
 			
 		/**
+		 * Liste des participants pnj
+		 */
+			$controllers->match('/{gn}/participants/pnj', 'LarpManager\Controllers\GnController::pnjsAction')
+			->assert('gn', '\d+')
+			->convert('gn', 'converter.gn:convert')
+			->bind("gn.participants.pnj")
+			->before($mustBeAdmin);
+			
+		/**
 		 * Liste des participants à un gn n'ayant pas encore de billet
 		 */
 		$controllers->match('/{gn}/participants/withoutbillet.csv', 'LarpManager\Controllers\GnController::participantsWithoutBilletCSVAction')

--- a/src/LarpManager/Views/admin/personnage/detail.twig
+++ b/src/LarpManager/Views/admin/personnage/detail.twig
@@ -24,7 +24,7 @@
 			
 			<small>{{ personnage.ageReel|default('x') }} ans ({{ personnage.age }})</small>
 			
-			{% if personnage.vivant %}<span class="text-success">Vivant</span>{% else %}<span class="text-danger">Mort</span>{% endif %}
+			{% if personnage.vivant %}<span class="text-success">⚔️ Vivant</span>{% else %}<span class="text-danger">💀 Mort</span>{% endif %}{% if personnage.isPnj() %} 🎭 PNJ{% endif %}
 			
 			<div class="pull-right">
 				{{ personnage.classeName }}

--- a/src/LarpManager/Views/admin/personnage/detail.twig
+++ b/src/LarpManager/Views/admin/personnage/detail.twig
@@ -11,7 +11,7 @@
 	</ol>
 		
 	<div class="well well-sm">
-		<h3>
+		<h3>{% if personnage.isPnj() %} 🎭 PNJ - {% endif %}
 			{{ personnage.nom }}{% if personnage.surnom %} <small>({{ personnage.surnom }})</small>{% endif %}
 			
 			{% if personnage.genre == 'Masculin' %}
@@ -24,7 +24,7 @@
 			
 			<small>{{ personnage.ageReel|default('x') }} ans ({{ personnage.age }})</small>
 			
-			{% if personnage.vivant %}<span class="text-success">⚔️ Vivant</span>{% else %}<span class="text-danger">💀 Mort</span>{% endif %}{% if personnage.isPnj() %} 🎭 PNJ{% endif %}
+			{% if personnage.vivant %}<span class="text-success">Vivant</span>{% else %}<span class="text-danger">💀 Mort</span>{% endif %}
 			
 			<div class="pull-right">
 				{{ personnage.classeName }}

--- a/src/LarpManager/Views/admin/personnage/list.twig
+++ b/src/LarpManager/Views/admin/personnage/list.twig
@@ -98,7 +98,7 @@
 			{% for personnage in personnages %}
 				<tr>
 					<td>{{ personnage.id }}</td>
-					<td>{% if personnage.vivant == 0 %}💀 {% endif %}<a href="{{ path('personnage.admin.detail', {'personnage':personnage.id}) }}">{{ personnage.nom }}{% if personnage.surnom %} ({{ personnage.surnom }}){% endif %}</a></td>
+					<td>{% if personnage.vivant == 0 %}💀 {% else %}⚔️ {% endif %}<a href="{{ path('personnage.admin.detail', {'personnage':personnage.id}) }}">{{ personnage.nom }}{% if personnage.surnom %} ({{ personnage.surnom }}){% endif %}</a>&nbsp;{% if personnage.isPnj() %}🎭 {% endif %}</td>
 					<td>{{ personnage.classeName }}</td>
 					<td>
 						{% set gn = 'LH1' %}

--- a/src/LarpManager/Views/admin/personnage/list.twig
+++ b/src/LarpManager/Views/admin/personnage/list.twig
@@ -47,7 +47,10 @@
 					{{ form_rest(form) }}
 		   		</form>
 			</div>
-			{{ paginator|raw }}
+			<div class="paginator-container">
+				{{ paginator|raw }}
+				<div class="legend"><span class="legend-header">Légende :</span> 💀 = Mort, 🎭 = PNJ</div>
+			</div>
 
 	<table class="table table-striped table-bordered table-condensed table-hover">
 		<thead>
@@ -98,7 +101,7 @@
 			{% for personnage in personnages %}
 				<tr>
 					<td>{{ personnage.id }}</td>
-					<td>{% if personnage.vivant == 0 %}💀 {% else %}⚔️ {% endif %}<a href="{{ path('personnage.admin.detail', {'personnage':personnage.id}) }}">{{ personnage.nom }}{% if personnage.surnom %} ({{ personnage.surnom }}){% endif %}</a>&nbsp;{% if personnage.isPnj() %}🎭 {% endif %}</td>
+					<td>{% if personnage.isPnj() %}🎭 {% else %}{% if personnage.vivant == 0 %}💀 {% else %}<span class="invisible">💀 </span>{% endif %}{% endif %}<a href="{{ path('personnage.admin.detail', {'personnage':personnage.id}) }}">{{ personnage.nom }}{% if personnage.surnom %} ({{ personnage.surnom }}){% endif %}</a></td>
 					<td>{{ personnage.classeName }}</td>
 					<td>
 						{% set gn = 'LH1' %}

--- a/src/LarpManager/Views/gn/detail.twig
+++ b/src/LarpManager/Views/gn/detail.twig
@@ -34,6 +34,7 @@
 				
 				<ul>
 					<li><a href="{{ path('gn.participants', {'gn': gn.id}) }}"><i class="fa fa-users"></i> Participants ({{ gn.participants|length }})</a></li>
+					<li><a href="{{ path('gn.participants.pnj', {'gn': gn.id}) }}"><i class="fa fa-users"></i> Participants PNJs ({{ gn.participantspnj|length }})</a></li>
 					<li><a href="{{ path('gn.participants.withoutbillet', {'gn': gn.id}) }}"><i class="fa fa-users"></i> Participants sans billet ({{ gn.participantswithoutbillet|length }})</a></li>
 					<li><a href="{{ path('gn.participants.withoutgroup', {'gn': gn.id}) }}"><i class="fa fa-users"></i> Participants sans groupe (mais avec billet) ({{ gn.participantswithoutgroup|length }})</a></li>
 					<li><a href="{{ path('gn.participants.withoutperso', {'gn': gn.id}) }}"><i class="fa fa-users"></i> Participants sans personnage ({{ gn.participantswithoutperso|length }})</a></li>

--- a/src/LarpManager/Views/gn/pnjs.twig
+++ b/src/LarpManager/Views/gn/pnjs.twig
@@ -8,7 +8,7 @@
 			<li><a href="{{ path('homepage')  }}">Accueil</a></li>
 			<li><a href="{{path('gn.list') }}">Liste des GNs</a></li>
 			<li><a href="{{path('gn.detail', {'gn': gn.id}) }}">{{ gn.label }}</a></li>
-			<li class="active">Les personnages non joueur</li>
+			<li class="active">Les personnages non joueurs</li>
 		</ol>
 		
 		<blockquote>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -150,3 +150,18 @@ ul.forum li
 	background-color: orange;
 	border-radius: 15px; 
 }
+
+.invisible {
+	/* already exists in bootstrap but just in case we replace the bootstrap css theme someday, redefine it */
+	visibility: hidden;
+}
+
+.paginator-container {
+	display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.legend-header  {
+	font-weight: bold;
+}


### PR DESCRIPTION
ajout de isPnj méthodes basés sur le label du billet contient pnj (d'après méthode similaire sur class gn getParticipantsPnj) et icones pour recherche et detail

note: l'icone PNJ est mise à droite du nom pour garder l'autre statut vivant/mort bien aligné

![image](https://user-images.githubusercontent.com/81388752/156896341-4d2fdccd-9fb3-43d7-b645-8f51fddfca4f.png)

![image](https://user-images.githubusercontent.com/81388752/156896355-39ff557e-9f94-4e04-8187-0134380d292f.png)

![image](https://user-images.githubusercontent.com/81388752/156896364-4ecf3cf3-a249-4fa1-8982-d332f380fb03.png)

utilise la nouvelle méthode isPnj dans gn.getParticipantsPnj et rajout de la liste des participants pnj sur la partie admin de la page du gn
![image](https://user-images.githubusercontent.com/81388752/156898475-6a798a9c-925e-4f22-904b-769d9b6344fb.png)
![image](https://user-images.githubusercontent.com/81388752/156898525-b3ef0256-270a-44ca-b2b3-747115160bb1.png)
