### PR TITLE
Ajout du BG personnage sur la fiche

### DIFF
--- a/src/LarpManager/Views/public/personnage/detail.twig
+++ b/src/LarpManager/Views/public/personnage/detail.twig
@@ -104,6 +104,7 @@
 					{% include 'public/personnage/fragment/politique.twig' with {'personnage': personnage, 'participant': participant, 'lois': lois} %}
 					{% include 'public/personnage/fragment/priere.twig' with {'personnage': personnage, 'participant': participant} %}
 					{% include 'public/personnage/fragment/religion.twig' with {'personnage': personnage, 'participant': participant} %}
+					{% include 'public/personnage/fragment/background.twig' with {'personnage': personnage, 'participant': participant} %}
 				</div>
 			</div>
 

--- a/src/LarpManager/Views/public/personnage/fragment/background.twig
+++ b/src/LarpManager/Views/public/personnage/fragment/background.twig
@@ -1,0 +1,15 @@
+{# Background #}
+<div class="header">
+	<h5>Background</h5>
+</div>
+
+{% if personnage.backgrounds('OWNER')|length > 0 %}
+	{% for background in personnage.personnageBackgrounds %}
+		<h6 class="list-group-item-heading">Background</h6>
+		{{ background.text|markdown }}
+	{% endfor %}
+{% else %}
+	<p class="list-group-item-text">
+		Ce personnage n'a pas de background individuel.
+	</p>
+{% endif %}


### PR DESCRIPTION
Si le BG existe et est disponible pour sa visibilité, il sera affiché sur la fiche de détail du personnage

<img width="1448" alt="image" src="https://user-images.githubusercontent.com/1568376/230997438-5ba64f41-8a74-40e6-a8ab-4a4c0aa864cb.png">

fix #421 