### PR TITLE
Ajout du materiel de langue sur l'export de personnage

### DIFF
--- a/src/LarpManager/Controllers/PersonnageController.php
+++ b/src/LarpManager/Controllers/PersonnageController.php
@@ -2573,6 +2573,7 @@ class PersonnageController
 		return $app['twig']->render('admin/personnage/print.twig', array(
 				'personnage' => $personnage,
 				'participant' => $participant,
+                'langueMateriel' => $this->getLangueMateriel($personnage),
 				'groupe' => $groupe,
 			));
 	}

--- a/src/LarpManager/Views/admin/personnage/print.twig
+++ b/src/LarpManager/Views/admin/personnage/print.twig
@@ -89,6 +89,15 @@ table tr td {
 						<strong>{{ personnageLangue.langue}}</strong> ({{ personnageLangue.source }})<br />
 					{% endfor %}
 				</td>
+				<td>
+					<ul>
+						{% for materiel in langueMateriel %}
+							<li><strong>{{ materiel }}</strong></li>
+						{% else %}
+							<li>Aucun matériel</li>
+						{% endfor %}
+					</ul>
+				</td>
 			</tr>
 		</tbody>
 	</table>		


### PR DESCRIPTION
Présent sur la page détail perso admin, et impression enveloppe, il manque sur la page export de personnage

<img width="492" alt="image" src="https://user-images.githubusercontent.com/1568376/233741132-8737de16-dfc5-4928-9b30-746563567dfb.png">
