### PR TITLE
Optimisation de la page stock/objet

### DIFF
--- a/src/LarpManager/Form/ObjetFindForm.php
+++ b/src/LarpManager/Form/ObjetFindForm.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * LarpManager - A Live Action Role Playing Manager
+ * Copyright (C) 2016 Kevin Polez
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace LarpManager\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * LarpManager\Form\ObjetFindForm
+ *
+ * @author Gectou4
+ *
+ */
+class ObjetFindForm extends AbstractType
+{
+	/**
+	 * Construction du formulaire
+	 * 
+	 * @param FormBuilderInterface $builder
+	 * @param array $options
+	 */
+	public function buildForm(FormBuilderInterface $builder, array $options)
+	{
+		$builder->add('value','text', array(
+					'required' => true,	
+					'label' => 'Recherche',
+				))
+				->add('type','choice', array(
+					'required' => true,
+					'choices' => array(
+						'nom' => 'Nom',
+						'description' => 'Description',
+						'numero' => 'Numero',
+					),
+					'label' => 'Type',
+				));
+	}
+	
+	/**
+	 * Définition de l'entité concernée
+	 * 
+	 * @param OptionsResolverInterface $resolver
+	 */
+	public function setDefaultOptions(OptionsResolverInterface $resolver)
+	{
+	}
+	
+	/**
+	 * Nom du formulaire
+	 */
+	public function getName()
+	{
+		return 'objetFind';
+	}
+}

--- a/src/LarpManager/Repository/ObjetRepository.php
+++ b/src/LarpManager/Repository/ObjetRepository.php
@@ -21,95 +21,119 @@
 namespace LarpManager\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 
 /**
  * LarpManager\Repository\ObjetRepository
- * 
+ *
  * @author kevin
  */
 class ObjetRepository extends EntityRepository
 {
-	/**
-	 * Trouve tous les objets
-	 */
-	public function findAll()
-	{
-		$qb = $this->getEntityManager()->createQueryBuilder();
-		
-		$qb->select('o');
-		$qb->from('LarpManager\Entities\Objet','o');
-		$qb->orderBy('o.id','DESC');
-		return $qb->getQuery()->getResult();
-	}
-	
-	/**
-	 * Trouve tous les objets correspondant au tag
-	 * @return ArrayCollection $classes
-	 */
-	public function findByTag($tag)
-	{
-		$qb = $this->getEntityManager()->createQueryBuilder();
-		
-		$qb->select('o');
-		$qb->from('LarpManager\Entities\Objet','o');
-		$qb->join('o.photo','p');
-		$qb->join('o.tags','t');
-		$qb->where('t.nom LIKE :tag');
-		$qb->orderBy('o.id','DESC');
-		$qb->setParameter('tag', $tag->getNom());
-		
-		return $qb->getQuery()->getResult();
-	}
-	
-	/**
-	 * Trouve tous les objets sans tag
-	 * @return ArrayCollection $classes
-	 */
-	public function findWithoutTag()
-	{
-		$qb = $this->getEntityManager()->createQueryBuilder();
-		
-		$qb->select('o');
-		$qb->from('LarpManager\Entities\Objet','o');
-		$qb->orderBy('o.id','DESC');
-		$qb->leftjoin('o.tags','t');
-		$qb->where('t.id is null');
-				
-		return $qb->getQuery()->getResult();
-	}
-	
-	/**
-	 * Trouve tous les objets correspondant au tag
-	 * @return ArrayCollection $classes
-	 */
-	public function findByRangement($rangement)
-	{
-		$qb = $this->getEntityManager()->createQueryBuilder();
-	
-		$qb->select('o');
-		$qb->from('LarpManager\Entities\Objet','o');
-		$qb->join('o.rangement','r');
-		$qb->where('r.id = :rangement');
-		$qb->orderBy('o.id','DESC');
-		$qb->setParameter('rangement', $rangement->getId());
-	
-		return $qb->getQuery()->getResult();
-	}
-	
-	/**
-	 * Trouve tous les objets sans rangement
-	 * @return ArrayCollection $classes
-	 */
-	public function findWithoutRangement()
-	{
-		$qb = $this->getEntityManager()->createQueryBuilder();
-	
-		$qb->select('o');
-		$qb->from('LarpManager\Entities\Objet','o');
-		$qb->leftjoin('o.rangement','r');
-		$qb->orderBy('o.id','DESC');
-		$qb->where('r.id is null');
-	
-		return $qb->getQuery()->getResult();
-	}
+    public const CRIT_WITHOUT = -1;
+
+    /**
+     * Trouve tous les objets
+     */
+    public function findAll()
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+
+        $qb->select('o');
+        $qb->from('LarpManager\Entities\Objet', 'o');
+        $qb->orderBy('o.id', 'DESC');
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Trouve le nombre d'objets correspondant aux critères de recherche
+     */
+    public function findCount(array $criteria)
+    {
+        $qb = $this->getQueryBuilder($criteria);
+        $qb->select($qb->expr()->count('distinct o'));
+
+        return $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * Trouve les potions correspondant aux critères de recherche
+     */
+    public function findList(array $criteria, array $order = [], int $limit = 50, int $offset = 0)
+    {
+        $qb = $this->getQueryBuilder($criteria);
+        $qb->setFirstResult($offset);
+        $qb->setMaxResults($limit);
+        $qb->orderBy('o.' . $order['by'], $order['dir']);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @param array $criteria
+     * @return QueryBuilder
+     */
+    protected function getQueryBuilder(array $criteria): QueryBuilder
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+
+        $qb->select('o');
+        $qb->from('LarpManager\Entities\Objet', 'o', 'o');
+        $qb->join('o.photo', 'p');
+
+        $allowed = ['nom', 'description', 'numero'];
+        foreach ($allowed as $field) {
+            if ($criteria[$field] ?? false) {
+                $qb->andWhere('o.' . $field . ' LIKE :field ');
+                $qb->setParameter('field', '%' . $criteria[$field] . '%');
+            }
+        }
+
+        if ($criteria['tag'] ?? false) {
+            $criter = $criteria['tag'];
+
+            if (is_numeric($criter)) {
+                $criter = (int)$criter;
+
+                if ($criter === -1) {
+                    $qb->leftjoin('o.tags', 't');
+                    $qb->where('t.id is null');
+                } else {
+                    $qb->join('o.tags', 't');
+                    $qb->where('t.id = :tag');
+                    $qb->setParameter('tag', $criter);
+                }
+            } else {
+                $qb->join('o.tags', 't');
+                $qb->where('t.nom LIKE :tag');
+                $qb->setParameter('tag', $criter);
+            }
+        }
+
+        if ($criteria['numero'] ?? false) {
+            $qb->andWhere('o.numero LIKE :numero');
+            $qb->setParameter('numero', $criteria['numero']);
+        }
+
+        if (isset($criteria['rangement'])) {
+            $criter = $criteria['rangement'];
+
+            if (is_numeric($criter)) {
+                $criter = (int)$criter;
+                if ($criter === -1) {
+                    $qb->leftjoin('o.rangement', 'r');
+                    $qb->where('r.id is null');
+                } else {
+                    $qb->where('o.rangement = :rangement');
+                    $qb->setParameter('rangement', $criter);
+                }
+            } else {
+                $qb->join('o.rangement', 'r');
+                $qb->where('r.label LIKE :rangement');
+                $qb->setParameter('rangement', $criter);
+            }
+        }
+
+        return $qb;
+    }
 }

--- a/src/LarpManager/Views/admin/stock/objet/list.twig
+++ b/src/LarpManager/Views/admin/stock/objet/list.twig
@@ -16,67 +16,118 @@
 		<li><a href="{{ path('homepage') }}">Accueil</a></li>
 		<li class="active">Objets</li>
 	</ol>
-	
-	
+
 	<nav class="navbar navbar-default" style="padding-right: 5px;">
-		<div class="navbar-header">
-			<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-2" aria-expanded="false">
-		        <span class="sr-only">Toggle navigation</span>
-		        <span class="icon-bar"></span>
-		        <span class="icon-bar"></span>
-		        <span class="icon-bar"></span>
-			</button>
-			<span class="navbar-brand">
-				{% if tag %}
-					Vous listez les objets correspondant au tag <strong>{{tag.nom }}</strong>&nbsp;<small>{{ objets|length }} objet(s)</small>
-				{% elseif tagId == -1 %}
-					Vous listez tous les objets sans tags&nbsp;<small>{{ objets|length }} objet(s)</small>
-				{% elseif rangement %}
-					Vous listez les objets correspondant au rangement <strong>{{rangement.label }}</strong>&nbsp;<small>{{ objets|length }} objet(s)</small>
-				{% elseif rangementId == -1 %}
-					Vous listez tous les objets sans rangement&nbsp;<small>{{ objets|length }} objet(s)</small>
-				{% else %}
-					Vous listez tous les objets&nbsp;<small>{{ objets|length }} objet(s)</small>
-				{% endif %}
-			</span>
+
+		<div class="flex-container">
+
+			<div class="flex-item">
+				<form class="form-inline" action="{{ path('stock_objet_index', {'order_by': 'nom', 'order_dir': 'DESC'}) }}" method="POST" {{ form_enctype(form) }}>
+					{% form_theme form 'Form/bootstrap_3_layout.html.twig' %}
+					<div class="form-group">
+						<div class="input-group">
+							{{ form_widget(form.value) }}
+						</div>
+						<div class="input-group">
+							{{ form_widget(form.type) }}
+							<div class="input-group-btn">
+								<button type="submit" class="btn btn-default" data-toggle="tooltup" data-placement="top" title="Lancer la recherche"><i class="fa fa-search"></i></button>
+								<a class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Reset" href="{{ path('stock_objet_index', {'order_by': 'nom', 'order_dir': 'DESC'}) }}"><i class="fa fa-refresh"></i></a>
+							</div>
+						</div>
+					</div>
+					{{ form_rest(form) }}
+				</form>
+
+
+			</div>
+
+			<div class="flex-item-center flex-column">
+				<div  class="flex-item-center">
+					{{ paginator|raw }}
+				</div>
+
+				<div class="flex-item-center">
+
+						{% if paginator.totalItems == 1 %}
+							<strong>1</strong>&nbsp;objet trouvé
+						{% else %}
+							<strong>{{ paginator.totalItems }}</strong>&nbsp;objets trouvés
+						{% endif %}
+
+						{% if paginator.totalItems >= 1 %}
+						&nbsp;Montre&nbsp;<strong>{{ paginator.currentPageFirstItem }} - {{ paginator.currentPageLastItem }}</strong>
+						{% endif %}
+
+						{% if tag == -1 %}
+							&nbsp;- Sans tag
+						{% endif %}
+
+						{% if rangement == -1 %}
+							&nbsp;- sans rangement
+						{% endif %}
+
+				</div>
+			</div>
+
+			<div class="flex-item-right">
+				<div id="bs-example-navbar-collapse-2" class="collapse navbar-collapse">
+					<ul class="nav navbar-nav navbar-right">
+						<li role="presentation" class="dropdown">
+							<a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+								Tags
+								<span class="caret"></span>
+							</a>
+							<ul class="dropdown-menu">
+								{% for tag in tags %}
+									<li><a href="{{ path('stock_objet_index', {'tag':tag.id, 'rangement':rangement}) }}">{{ tag.nom }}&nbsp</a></li>
+								{% endfor %}
+								<li><a href="{{ path('stock_objet_index', {'tag':-1, 'rangement':rangement}) }}">Objets sans tag&nbsp;({{ objetsWithoutTagCount }})</a></li>
+							</ul>
+						</li>
+						<li role="presentation" class="dropdown">
+							<a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+								Rangements
+								<span class="caret"></span>
+							</a>
+							<ul class="dropdown-menu">
+								{% for rangement in rangements %}
+									<li><a href="{{ path('stock_objet_index', {'rangement':rangement.id, 'tag':tag}) }}">{{ rangement.label }}</a></li>
+								{% endfor %}
+								<li><a href="{{ path('stock_objet_index', {'rangement':-1, 'tag':tag}) }}">Objets sans rangement&nbsp;{{ objetsWithoutRangementCount }}</a></li>
+							</ul>
+						</li>
+						<a href="{{ path('stock_objet_add') }}" class="btn btn-primary navbar-btn">Créer un nouvel objet</a>
+					</ul>
+				</div>
+			</div>
+
 		</div>
-		<div id="bs-example-navbar-collapse-2" class="collapse navbar-collapse">
-			<ul class="nav navbar-nav navbar-right">
-				<li role="presentation" class="dropdown">
-					<a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-	      				Tags
-	      				<span class="caret"></span>
-	    			</a>
-	    			<ul class="dropdown-menu">
-		    			{% for tag in tags %}
-							<li><a href="{{ path('stock_objet_index', {'tag':tag.id}) }}">{{ tag.nom }}&nbsp;({{ tag.objets|length }})</a></li>
-						{% endfor %}
-						<li><a href="{{ path('stock_objet_index', {'tag':-1}) }}">Objets sans tag&nbsp;({{ objetsWithoutTagCount }})</a></li>
-					</ul>
-	    		</li>
-	    		<li role="presentation" class="dropdown">
-					<a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-	      				Rangements
-	      				<span class="caret"></span>
-	    			</a>
-	    			<ul class="dropdown-menu">
-	    				{% for rangement in rangements %}
-							<li><a href="{{ path('stock_objet_index', {'rangement':rangement.id}) }}">{{ rangement.label }}&nbsp;{{ rangement.objets|length }}</a></li>
-						{% endfor %}
-						<li><a href="{{ path('stock_objet_index', {'rangement':-1}) }}">Objets sans rangement&nbsp;{{ objetsWithoutRangementCount }}</a></li>
-					</ul>
-	    		</li>
-	    		<a href="{{ path('stock_objet_add') }}" class="btn btn-primary navbar-btn">Créer un nouvel objet</a>
-	    	</ul>
-	    </div>
-	</nav> 
-			
+
+	</nav>
 			
 	<div class="well well-sm">
 	 	<table class="table">
 	 		<thead>
 	 			<tr>
-	 				<th>Nom</th>
+	 				<th>
+						{% if app.request.get('order_dir') == 'ASC' and app.request.get('order_by') == 'nom' %}
+							<a href="{{ path('stock_objet_index', {'order_by': 'nom', 'order_dir': 'DESC', 'tag':tag, 'rangeemnt': rangement}) }}">
+						{%  else %}
+							<a href="{{ path('stock_objet_index', {'order_by': 'nom', 'order_dir': 'ASC', 'tag':tag, 'rangeemnt': rangement}) }}">
+						{% endif %}
+							Nom
+						{% if app.request.get('order_by') == 'nom'  %}
+							{% if app.request.get('order_dir') == 'ASC' %}
+								<span class="caret"></span>
+							{% else %}
+								<span class="dropup">
+									<span class="caret"></span>
+								</span>
+							{% endif %}
+						{% endif %}
+						</a>
+					</th>
 	 				<th>Photo</th>
 	 				<th>Description</th>
 	 				<th>Tags</th>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -156,10 +156,33 @@ ul.forum li
 	visibility: hidden;
 }
 
-.paginator-container {
+.paginator-container, .flex-container {
 	display: flex;
     align-items: center;
     justify-content: space-between;
+}
+
+.flex-item, .flex-item-center {
+	display: flex;
+	flex-grow: 1;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.flex-item-center {
+	justify-content: center;
+}
+
+.flex-column {
+	flex-direction: column;
+}
+
+.right {
+	justify-content: right;
+}
+
+.flex-item + .flex-item {
+	margin-left: 2%;
 }
 
 .legend {


### PR DESCRIPTION
<img width="1380" alt="Capture d’écran 2023-04-27 à 00 14 53" src="https://user-images.githubusercontent.com/1568376/234715441-7b1b920c-1722-4190-aac4-ec6ac29400b6.png">

Ajout d'une pagination
Ajout d'une recherche
On factorise quelque critère pour les combiner
On join des données qui seront demandées par la page On retire les counts par rangement/tags qui alourdissent la page

Tweak possible : passer le nombre d'objet par page à 25 au lieu de 50

Si besoin de remettre les compteurs par tag/rangement : 
```bash
({{ tag.objets|length }})
{{ rangement.objets|length }}
```

Ils ont été retirés, car alourdit conséquemment la page.
 On pourra voir par la suite l'emploi de Query plus efficace mais il me faudra creuser la souplesse de Doctrine pour des query du genre : 
```sql
SELECT COUNt(*) AS nb, tag_id FROM objet_tag GROUP BY tag_id;

SELECT COUNt(*) AS nb, rangement_id FROM objet GROUP BY rangement_id;
``` 
Elles permettent d'avoir le nombre d'objets par tag/rangement en 2 requêtes optimisées et non plus en 1 requête par tag/rangement pour l'affichage d'une dropdown pas toujours consultée.

Le total reste disponible au besoin via l'ajout du paginator si on choisie le tag/rangement.

# Autres optim possibles

- Voir pour basculer le choix du tag/rangement dans le formulaire ce qui pourrait simplifier encore plus 
- Vérifier/Créer l'index SQL sur rangement_id 

