### PR TITLE
correction des affichages lié a la relation user.personnage

### DIFF
--- a/src/LarpManager/Entities/Personnage.php
+++ b/src/LarpManager/Entities/Personnage.php
@@ -1422,12 +1422,22 @@ class Personnage extends BasePersonnage
 	 */
 	public function isSensible()
 	{
-		$naissance = $this->getUser()->getEtatCivil()->getDateNaissance();
+        $user  = $this->getUser();
+        $participant = $this->getLastParticipant();
+        if (!$user && $participant) {
+            $user = $participant->getUser();
+        }
+
+        $naissance = null;
+        if ($user) {
+		    $naissance = $user->getEtatCivil()->getDateNaissance();
+        }
+
 		foreach ($this->participants as $p) {
 			$gn_date = $p->getGn()->getDateDebut();
 		}
 
-		if (!isset($gn_date))
+		if (!isset($gn_date) || !$naissance)
 			return $this->getSensible();
 
 		$interval = date_diff($gn_date, $naissance);

--- a/src/LarpManager/Views/gn/participants.twig
+++ b/src/LarpManager/Views/gn/participants.twig
@@ -90,8 +90,10 @@
 						{% endif %}
 					</td>
 					<td>
-						{% if participant.user.personnage %}
+						{% if participant.personnage is empty and participant.user.personnage %}
 							<a href="{{ path('personnage.admin.detail', {'personnage': participant.user.personnage.id}) }}">{{ participant.user.personnage.nom }}</a>
+						{% elseif participant.user.personnage is empty and participant.personnage %}
+							<a href="{{ path('personnage.admin.detail', {'personnage': participant.personnage.id}) }}">{{ participant.personnage.nom }}</a>
 						{% else %}
 							<span class="text-danger">Aucun personnage sélectionné</span>
 						{% endif %}

--- a/src/LarpManager/Views/public/groupe/fragment/detail.twig
+++ b/src/LarpManager/Views/public/groupe/fragment/detail.twig
@@ -25,7 +25,7 @@
 </div>
 
 {% if groupe.scenariste %}
-	{ groupe.scenariste.etatCivil }}&nbsp;({{ groupe.scenariste.email }})
+	{{ groupe.scenariste.etatCivil }}&nbsp;({{ groupe.scenariste.email }})
 {% else %}
 	<span class="fa fa-exclamation-triangle" aria-hidden="true"></span>&nbsp;Attention, ce groupe n'a pas de scénariste.
 {% endif %}


### PR DESCRIPTION
Ajout d'un fallback si user.personnage n'est pas défini mais que l'user est bien lier au participant du personnage

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/1568376/235260472-f6d37c38-d08a-4ed7-8649-ee83c11fe95b.png">



A vérifier : Il semble qu'à la création du personnage. Si personnage.user_id est bien enregistré. User.personnage_id lui ne l'est pas.