### PR TITLE
Correction de l'erreur variable participant does not exists

### DIFF
--- a/src/LarpManager/Views/admin/personnage/detail.twig
+++ b/src/LarpManager/Views/admin/personnage/detail.twig
@@ -291,11 +291,16 @@
 							<h6>Technologies :</h6>
 							<div class="list-group">
 								<div class="list-group-item">
-									{% for technologie in participant.personnage.technologies %}
-										<div class="list-group-item-text">{% if technologie.secret %}<span style="color:red;">Secret</span> - {% endif %}{{ technologie.label }}</div>
-									{% else %}
-										<div class="list-group-item-text">Aucune</div>
-									{% endfor %}
+									{% if personnage.user %}
+										{% set participant = personnage.user.participants|last %}
+										{%  if participant %}
+											{% for technologie in participant.personnage.technologies %}
+												<div class="list-group-item-text">{% if technologie.secret %}<span style="color:red;">Secret</span> - {% endif %}{{ technologie.label }}</div>
+											{% else %}
+												<div class="list-group-item-text">Aucune</div>
+											{% endfor %}
+										{% endif %}
+									{% endif %}
 								</div>
 							</div>
 


### PR DESCRIPTION
Sur la page de détail admin d'un personnage

Si un user n'est pas lié à un personnage, participant n'est jamais défini plus au dans la page et donc la variable n'existera pas cela provoque une erreur.
