### PR TITLE
Fix 168 langue order

### DIFF
--- a/src/LarpManager/Controllers/GnController.php
+++ b/src/LarpManager/Controllers/GnController.php
@@ -94,6 +94,7 @@ class GnController
         $descendants =  $app['orm.em']->getRepository(Personnage::class)->findDescendants($personnage);
         return $app['twig']->render('public/personnage/detail.twig', array(
             'personnage' => $personnage,
+            'personnageLangues' => $app['orm.em']->getRepository(Personnage::class)->findOrderedLangages($personnage),
             'participant' => $participant,
             'lois' => $lois,
             'descendants' => $descendants

--- a/src/LarpManager/Controllers/PersonnageController.php
+++ b/src/LarpManager/Controllers/PersonnageController.php
@@ -695,10 +695,20 @@ class PersonnageController
 	public function adminDetailAction(Request $request, Application $app)
 	{
 		$personnage = $request->get('personnage');
-		//$personnageLangues = $personnage->getPersonnageLangues();
-				$descendants =  $app['orm.em']->getRepository(Personnage::class)->findDescendants($personnage);
+        $descendants =  $app['orm.em']->getRepository(Personnage::class)->findDescendants($personnage);
 
-		return $app['twig']->render('admin/personnage/detail.twig', array('personnage' => $personnage, 'descendants' => $descendants, 'langueMateriel' => $this->getLangueMateriel($personnage)));
+        // Use Database order : meilleur que celui de Twig
+        $personnageLangues = $app['orm.em']->getRepository(Personnage::class)->findOrderedLangages($personnage);
+
+		return $app['twig']->render(
+            'admin/personnage/detail.twig',
+            array(
+                'personnage' => $personnage,
+                'personnageLangues' => $personnageLangues,
+                'descendants' => $descendants,
+                'langueMateriel' => $this->getLangueMateriel($personnage),
+            )
+        );
 	}
 
 	/**

--- a/src/LarpManager/Repository/PersonnageRepository.php
+++ b/src/LarpManager/Repository/PersonnageRepository.php
@@ -21,6 +21,8 @@
 namespace LarpManager\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use LarpManager\Entities\Personnage;
+use LarpManager\Entities\PersonnageLangues;
 use LarpManager\Entities\PersonnageLignee;
 use Doctrine\ORM\QueryBuilder;
 
@@ -212,7 +214,26 @@ LEFT JOIN p2.participants pa2
 
         return $qb->getQuery()->getResult();
     }
-    
+
+    /**
+     * Fourni la liste des langues du personnage selon l'ordre :
+     * Secret Non/Oui, Diffusion décroissante, libellé de A à Z.
+     */
+    public function findOrderedLangages(Personnage $personnage): array
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+
+        $qb->select('pl');
+        $qb->from(PersonnageLangues::class, 'pl');
+        $qb->join('pl.langue','l');
+        $qb->where('pl.personnage = :personnage_id');
+        $qb->orderBy('l.secret','ASC');
+        $qb->addOrderBy('l.diffusion','DESC');
+        $qb->addOrderBy('l.label','ASC');
+        $qb->setParameter('personnage_id', $personnage->getId());
+
+        return $qb->getQuery()->getResult();
+    }
   
 }
 

--- a/src/LarpManager/Views/admin/personnage/detail.twig
+++ b/src/LarpManager/Views/admin/personnage/detail.twig
@@ -229,7 +229,7 @@
 							<div class="text-warning">{{languesAnomalie}}</div>
 							{% endif %}
 							<div class="list-group">
-								{% for personnageLangue in personnage.personnageLangues %}
+								{% for personnageLangue in personnageLangues %}
 									<div class="list-group-item">{% if personnageLangue.langue.secret %}<span style="color:red;">Secret</span> - {% endif %}<strong>{{ personnageLangue.langue}}</strong> ({{ personnageLangue.source }}) - <a href="{{ path('personnage.admin.langue.delete', {'personnage': personnage.id, 'personnageLangue' : personnageLangue.id }) }}">Supprimer</a></div>
 								{% endfor %}
 							</div>

--- a/src/LarpManager/Views/public/personnage/detail.twig
+++ b/src/LarpManager/Views/public/personnage/detail.twig
@@ -96,7 +96,7 @@
 					{% include 'public/personnage/fragment/groupeSecondaireMembre.twig' with {'personnage': personnage, 'participant': participant} %}
 					{% include 'public/personnage/fragment/alchimie.twig' with {'personnage': personnage, 'participant': participant} %}
 					{% include 'public/personnage/fragment/magie.twig' with {'personnage': personnage, 'participant': participant} %}
-					{% include 'public/personnage/fragment/language.twig' with {'personnage': personnage, 'participant': participant} %}
+					{% include 'public/personnage/fragment/language.twig' with {'personnage': personnage, 'participant': participant, 'personnageLangues': personnageLangues} %}
 					{% include 'public/personnage/fragment/technologie.twig' with {'personnage': personnage, 'participant': participant} %}
 					{% include 'public/personnage/fragment/connaissance.twig' with {'personnage': personnage, 'participant': participant} %}
 					{% include 'public/personnage/fragment/item.twig' with {'personnage': personnage, 'participant': participant} %}

--- a/src/LarpManager/Views/public/personnage/fragment/language.twig
+++ b/src/LarpManager/Views/public/personnage/fragment/language.twig
@@ -3,7 +3,7 @@
 	<h5>Langues connues</h5>
 </div>
 <ul class="list-group">
-	{% for personnageLangue in personnage.personnageLangues %}
+	{% for personnageLangue in personnageLangues %}
 		<li class="list-group-item">{% if personnageLangue.langue.secret %}<span style="color:red;">Secret</span> - {% endif %}<strong>{{ personnageLangue.langue }}</strong>&nbsp;<small>(obtenu grace à votre {{ personnageLangue.source }})</small><br />
 		{{ personnageLangue.langue.description|markdown }}
 		{% if personnageLangue.langue.documentUrl %}


### PR DESCRIPTION
fix #168 

@ErenHistarion je te laisse voir avec ton jeu de donnée sur les deux pages indiqué.

Il semble que les langues d'un personnage sont utilisé en beaucoup d'autre endroits:
- views/personnage/detail.twig => semble déprécié au profit de /views/public/personnage/detail.twig
- views/admin/personnage.print.twig => possiblement souhaité tel quel
- views/admin/group/printPerso.twig => possiblement souhaité tel quel
- views/admin/gn/printPerso.twig => possiblement souhaité tel quel
- views/admin/personnage/fiches.twig => a priori plus du tout utiliser 

J'aurais préféré utiliser directement l'annotation du BasePersonnage mais je n'ai pas encore trouvé la bonne façon de le faire.
Je me dis qu'on verra pour faire cela plus proprement pour lh7 ^^
