### PR TITLE
Ajout de pagination manquante sur les documents

### DIFF
--- a/src/LarpManager/Views/admin/document/index.twig
+++ b/src/LarpManager/Views/admin/document/index.twig
@@ -55,7 +55,7 @@
 		</ul>
 	</div>
 
-	<!--{ paginator|raw }-->
+	{{ paginator|raw }}
 
 		<table class="table table-condensed table-striped table-bordered">
 			<thead>


### PR DESCRIPTION
Ajoute la pagination manquante

<img width="1615" alt="image" src="https://github.com/eveoniris/larpManager-php/assets/1568376/7ef62d44-2150-4dff-952b-5c21bac1eb4c">
